### PR TITLE
[Enhancement] User TestCode 포맷팅

### DIFF
--- a/src/test/java/com/sopt/cherrish/domain/user/application/service/OnboardingServiceTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/user/application/service/OnboardingServiceTest.java
@@ -1,6 +1,7 @@
 package com.sopt.cherrish.domain.user.application.service;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 
 import org.junit.jupiter.api.DisplayName;
@@ -28,7 +29,7 @@ class OnboardingServiceTest {
 
 	@Test
 	@DisplayName("온보딩 프로필 생성 성공")
-	void createProfile_Success() {
+	void createProfileSuccess() {
 		// given
 		OnboardingRequestDto request = new OnboardingRequestDto("홍길동", 25);
 		User savedUser = UserFixture.createUser("홍길동", 25);

--- a/src/test/java/com/sopt/cherrish/domain/user/application/service/OnboardingServiceTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/user/application/service/OnboardingServiceTest.java
@@ -29,7 +29,7 @@ class OnboardingServiceTest {
 
 	@Test
 	@DisplayName("온보딩 프로필 생성 성공")
-	void createProfile_Success() {
+	void createProfileSuccess() {
 		// given
 		OnboardingRequestDto request = new OnboardingRequestDto("홍길동", 25);
 		User savedUser = UserFixture.createUser("홍길동", 25);

--- a/src/test/java/com/sopt/cherrish/domain/user/application/service/OnboardingServiceTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/user/application/service/OnboardingServiceTest.java
@@ -1,7 +1,8 @@
 package com.sopt.cherrish.domain.user.application.service;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.BDDMockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,7 +29,7 @@ class OnboardingServiceTest {
 
 	@Test
 	@DisplayName("온보딩 프로필 생성 성공")
-	void createProfile_Success() {
+	void createProfileSuccess() {
 		// given
 		OnboardingRequestDto request = new OnboardingRequestDto("홍길동", 25);
 		User savedUser = UserFixture.createUser("홍길동", 25);

--- a/src/test/java/com/sopt/cherrish/domain/user/application/service/UserServiceTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/user/application/service/UserServiceTest.java
@@ -1,7 +1,10 @@
 package com.sopt.cherrish.domain.user.application.service;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.BDDMockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.times;
+import static org.mockito.BDDMockito.verify;
 
 import java.util.Optional;
 
@@ -32,7 +35,7 @@ class UserServiceTest {
 
 	@Test
 	@DisplayName("사용자 조회 성공")
-	void getUser_Success() {
+	void getUserSuccess() {
 		// given
 		Long userId = 1L;
 		User user = UserFixture.createUser("홍길동", 25);
@@ -50,7 +53,7 @@ class UserServiceTest {
 
 	@Test
 	@DisplayName("사용자 조회 실패 - 존재하지 않는 사용자")
-	void getUser_NotFound() {
+	void getUserNotFound() {
 		// given
 		Long userId = 999L;
 		given(userRepository.findById(userId)).willReturn(Optional.empty());
@@ -63,7 +66,7 @@ class UserServiceTest {
 
 	@Test
 	@DisplayName("사용자 정보 수정 성공")
-	void updateUser_Success() {
+	void updateUserSuccess() {
 		// given
 		Long userId = 1L;
 		User user = UserFixture.createUser("홍길동", 25);
@@ -81,7 +84,7 @@ class UserServiceTest {
 
 	@Test
 	@DisplayName("사용자 정보 수정 실패 - 존재하지 않는 사용자")
-	void updateUser_NotFound() {
+	void updateUserNotFound() {
 		// given
 		Long userId = 999L;
 		UserUpdateRequestDto request = new UserUpdateRequestDto("김철수", 30);
@@ -95,7 +98,7 @@ class UserServiceTest {
 
 	@Test
 	@DisplayName("사용자 삭제 성공")
-	void deleteUser_Success() {
+	void deleteUserSuccess() {
 		// given
 		Long userId = 1L;
 		User user = UserFixture.createUser();
@@ -111,7 +114,7 @@ class UserServiceTest {
 
 	@Test
 	@DisplayName("사용자 삭제 실패 - 존재하지 않는 사용자")
-	void deleteUser_NotFound() {
+	void deleteUserNotFound() {
 		// given
 		Long userId = 999L;
 		given(userRepository.findById(userId)).willReturn(Optional.empty());

--- a/src/test/java/com/sopt/cherrish/domain/user/domain/model/UserTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/user/domain/model/UserTest.java
@@ -1,6 +1,6 @@
 package com.sopt.cherrish.domain.user.domain.model;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,7 +12,7 @@ class UserTest {
 
 	@Test
 	@DisplayName("User 생성 성공")
-	void createUser_Success() {
+	void createUserSuccess() {
 		// given & when
 		User user = UserFixture.createUser("홍길동", 25);
 
@@ -24,7 +24,7 @@ class UserTest {
 
 	@Test
 	@DisplayName("User 업데이트 - 이름과 나이 모두 수정")
-	void updateUser_BothFields() {
+	void updateUserBothFields() {
 		// given
 		User user = UserFixture.createUser("홍길동", 25);
 
@@ -38,7 +38,7 @@ class UserTest {
 
 	@Test
 	@DisplayName("User 업데이트 - null 값은 변경하지 않음")
-	void updateUser_NullValues() {
+	void updateUserNullValues() {
 		// given
 		User user = UserFixture.createUser("홍길동", 25);
 

--- a/src/test/java/com/sopt/cherrish/domain/user/fixture/UserFixture.java
+++ b/src/test/java/com/sopt/cherrish/domain/user/fixture/UserFixture.java
@@ -12,6 +12,10 @@ public class UserFixture {
 	private static final int DEFAULT_AGE = 25;
 	private static final Long DEFAULT_ID = 1L;
 
+	private UserFixture() {
+		// Utility class
+	}
+
 	public static User createUser() {
 		return createUser(DEFAULT_NAME, DEFAULT_AGE);
 	}

--- a/src/test/java/com/sopt/cherrish/domain/user/presentation/OnboardingControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/user/presentation/OnboardingControllerTest.java
@@ -1,8 +1,10 @@
 package com.sopt.cherrish.domain.user.presentation;
 
-import static org.mockito.BDDMockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDateTime;
 
@@ -34,7 +36,7 @@ class OnboardingControllerTest {
 
 	@Test
 	@DisplayName("온보딩 프로필 생성 성공")
-	void createProfile_Success() throws Exception {
+	void createProfileSuccess() throws Exception {
 		// given
 		OnboardingRequestDto request = new OnboardingRequestDto("홍길동", 25);
 
@@ -59,7 +61,7 @@ class OnboardingControllerTest {
 
 	@Test
 	@DisplayName("온보딩 프로필 생성 실패 - 유효하지 않은 입력")
-	void createProfile_InvalidInput() throws Exception {
+	void createProfileInvalidInput() throws Exception {
 		// given
 		OnboardingRequestDto request = new OnboardingRequestDto("", null);
 

--- a/src/test/java/com/sopt/cherrish/domain/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/user/presentation/UserControllerTest.java
@@ -1,8 +1,14 @@
 package com.sopt.cherrish.domain.user.presentation;
 
-import static org.mockito.BDDMockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDateTime;
 
@@ -34,7 +40,7 @@ class UserControllerTest {
 
 	@Test
 	@DisplayName("사용자 조회 성공")
-	void getUser_Success() throws Exception {
+	void getUserSuccess() throws Exception {
 		// given
 		Long userId = 1L;
 		UserResponseDto response = UserResponseDto.builder()
@@ -56,7 +62,7 @@ class UserControllerTest {
 
 	@Test
 	@DisplayName("사용자 정보 수정 성공")
-	void updateUser_Success() throws Exception {
+	void updateUserSuccess() throws Exception {
 		// given
 		Long userId = 1L;
 		UserUpdateRequestDto request = new UserUpdateRequestDto("김철수", 30);
@@ -83,7 +89,7 @@ class UserControllerTest {
 
 	@Test
 	@DisplayName("사용자 삭제 성공")
-	void deleteUser_Success() throws Exception {
+	void deleteUserSuccess() throws Exception {
 		// given
 		Long userId = 1L;
 		willDoNothing().given(userService).deleteUser(userId);


### PR DESCRIPTION
# 🛠 Related issue 🛠
- closed #10

# ✏️ Work Description ✏️
## 변경사항
- **테스트 코드 Checkstyle 경고 수정 (총 27개)**
- 와일드카드 임포트 제거 (15개)
    - `import static org.assertj.core.api.Assertions.*` → 명시적 임포트로 변경
    - `import static org.mockito.BDDMockito.*` → 명시적 임포트로 변경
    - `import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*` → 명시적 임포트로 변경
    - `import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*` → 명시적 임포트로 변경
- 테스트 메서드명 카멜케이스 변경 (11개)
    - 언더스코어 포함 메서드명 → 카멜케이스로 변경
    - 예: `getUser_Success` → `getUserSuccess`
- UserFixture 유틸리티 클래스 개선 (1개)
    - private 생성자 추가하여 인스턴스화 방지

## 문제 상황
### Checkstyle 경고가 발견된 배경
- `./gradlew build` 실행 시: Gradle의 **증분 빌드** 기능으로 인해 변경사항이 없으면 checkstyle 태스크를 건너뛰고 이전 결과를 재사용 (`UP-TO-DATE`)
- `./gradlew clean build` 실행 시: 모든 빌드 산출물을 삭제하고 처음부터 재빌드하므로 checkstyle이 실제로 실행되어 경고 출력
- Checkstyle 경고는 **WARN 레벨**이므로 빌드를 실패시키지 않아 평소에는 눈에 띄지 않음

### 발견된 Checkstyle 위반사항
Task :checkstyleTest
[ant:checkstyle] [WARN] AvoidStarImport: Using the '.' form of import should be avoided
[ant:checkstyle] [WARN] MethodName: Name 'getUser_Success' must match pattern '^[a-z][a-zA-Z0-9]$'
[ant:checkstyle] [WARN] HideUtilityClassConstructor: Utility classes should not have a public or default constructor

Checkstyle files with violations: 6
Checkstyle violations by severity: [warning:27]

## 해결 방식
### 1. AvoidStarImport 위반 해결
**문제**: 와일드카드 임포트(`.*`) 사용으로 인한 가독성 저하 및 네이밍 충돌 가능성

**해결**: 실제 사용하는 클래스/메서드만 명시적으로 임포트
```java
// Before
import static org.assertj.core.api.Assertions.*;
import static org.mockito.BDDMockito.*;

// After
import static org.assertj.core.api.Assertions.assertThat;
import static org.assertj.core.api.Assertions.assertThatThrownBy;
import static org.mockito.BDDMockito.given;
import static org.mockito.BDDMockito.times;
import static org.mockito.BDDMockito.verify;
```

2. MethodName 위반 해결

```java
문제: 테스트 메서드명에 언더스코어 사용 (Java 네이밍 컨벤션 위반)

해결: 카멜케이스로 변경
// Before                                                                                                                                                                                              
void getUser_Success() { }
void updateUser_NotFound() { }

// After                                                                                                                                                                                               
void getUserSuccess() { }
void updateUserNotFound() { }
```

3. HideUtilityClassConstructor 위반 해결

```java
문제: 유틸리티 클래스가 public 생성자를 가지고 있어 인스턴스화 가능

해결: private 생성자 추가하여 인스턴스화 방지
public class UserFixture {

private UserFixture() {
    // Utility class                                                                                                                                                                               
}

public static User createUser() { ... }
}

```

검증 결과

```java
$ ./gradlew clean checkstyleTest
> Task :checkstyleTest
BUILD SUCCESSFUL ✅

$ ./gradlew clean build
BUILD SUCCESSFUL in 1m ✅
12 actionable tasks: 12 executed
```

😅 Uncompleted Tasks 😅

- 없음

📢 To Reviewers 📢

- 테스트 메서드명이 변경되었으나 @DisplayName 어노테이션으로 한글 설명이 유지되므로 테스트 가독성에는 영향이 없습니다
- 모든 테스트가 정상 통과함을 확인했습니다
- 코드 스타일 개선 작업이므로 기능 변경은 없습니다