### PR TITLE
[Task] 사용자 시술 등록 구현

### DIFF
--- a/src/main/java/com/sopt/cherrish/domain/procedure/exception/ProcedureErrorCode.java
+++ b/src/main/java/com/sopt/cherrish/domain/procedure/exception/ProcedureErrorCode.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 public enum ProcedureErrorCode implements ErrorType {
 	// Procedure 도메인 에러 (P001 ~ P099)
 	INVALID_DOWNTIME_RANGE("P001", "다운타임 범위가 유효하지 않습니다. 최소 다운타임은 최대 다운타임보다 작거나 같아야 합니다", 400),
-	INVALID_DOWNTIME_VALUE("P002", "다운타임은 0 이상이어야 합니다", 400);
+	INVALID_DOWNTIME_VALUE("P002", "다운타임은 0 이상이어야 합니다", 400),
+	PROCEDURE_NOT_FOUND("P003", "시술을 찾을 수 없습니다", 404);
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/application/service/UserProcedureService.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/application/service/UserProcedureService.java
@@ -1,0 +1,61 @@
+package com.sopt.cherrish.domain.userprocedure.application.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
+import com.sopt.cherrish.domain.procedure.domain.repository.ProcedureRepository;
+import com.sopt.cherrish.domain.procedure.exception.ProcedureErrorCode;
+import com.sopt.cherrish.domain.procedure.exception.ProcedureException;
+import com.sopt.cherrish.domain.user.domain.repository.UserRepository;
+import com.sopt.cherrish.domain.user.exception.UserErrorCode;
+import com.sopt.cherrish.domain.user.exception.UserException;
+import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
+import com.sopt.cherrish.domain.userprocedure.domain.repository.UserProcedureRepository;
+import com.sopt.cherrish.domain.userprocedure.presentation.dto.request.UserProcedureCreateRequestDto;
+import com.sopt.cherrish.domain.userprocedure.presentation.dto.request.UserProcedureCreateRequestItemDto;
+import com.sopt.cherrish.domain.userprocedure.presentation.dto.response.UserProcedureListResponseDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserProcedureService {
+
+	private final UserRepository userRepository;
+	private final ProcedureRepository procedureRepository;
+	private final UserProcedureRepository userProcedureRepository;
+
+	@Transactional
+	public UserProcedureListResponseDto createUserProcedures(Long userId, UserProcedureCreateRequestDto request) {
+		validateUserExists(userId);
+
+		List<UserProcedure> userProcedures = new ArrayList<>();
+
+		for (UserProcedureCreateRequestItemDto item : request.getProcedures()) {
+			Procedure procedure = procedureRepository.findById(item.getProcedureId())
+				.orElseThrow(() -> new ProcedureException(ProcedureErrorCode.PROCEDURE_NOT_FOUND));
+
+			UserProcedure userProcedure = UserProcedure.builder()
+				.userId(userId)
+				.procedure(procedure)
+				.scheduledAt(request.getScheduledAt())
+				.downtimeDays(item.getDowntimeDays())
+				.build();
+			userProcedures.add(userProcedure);
+		}
+
+		List<UserProcedure> savedProcedures = userProcedureRepository.saveAll(userProcedures);
+		return UserProcedureListResponseDto.from(savedProcedures);
+	}
+
+	private void validateUserExists(Long userId) {
+		if (!userRepository.existsById(userId)) {
+			throw new UserException(UserErrorCode.USER_NOT_FOUND);
+		}
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/application/service/UserProcedureService.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/application/service/UserProcedureService.java
@@ -1,5 +1,6 @@
 package com.sopt.cherrish.domain.userprocedure.application.service;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -59,11 +60,11 @@ public class UserProcedureService {
 			Set<Long> foundIds = procedures.stream()
 				.map(Procedure::getId)
 				.collect(Collectors.toSet());
-			Set<Long> missingIds = procedureIds.stream()
-				.filter(id -> !foundIds.contains(id))
-				.collect(Collectors.toSet());
 
-			log.warn("Procedures not found: {}", missingIds);
+			Set<Long> missingIds = new HashSet<>(procedureIds);
+			missingIds.removeAll(foundIds);
+
+			log.warn("존재하지 않는 시술 ID: {}", missingIds);
 			throw new ProcedureException(ProcedureErrorCode.PROCEDURE_NOT_FOUND);
 		}
 

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/model/UserProcedure.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/model/UserProcedure.java
@@ -3,6 +3,7 @@ package com.sopt.cherrish.domain.userprocedure.domain.model;
 import java.time.LocalDateTime;
 
 import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
+import com.sopt.cherrish.domain.user.domain.model.User;
 import com.sopt.cherrish.global.entity.BaseTimeEntity;
 
 import jakarta.persistence.Column;
@@ -29,8 +30,9 @@ public class UserProcedure extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(nullable = false, name = "user_id")
-	private Long userId;
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
 
 	@ManyToOne(fetch = FetchType.LAZY, optional = false)
 	@JoinColumn(name = "procedure_id", nullable = false)
@@ -43,8 +45,8 @@ public class UserProcedure extends BaseTimeEntity {
 	private Integer downtimeDays;
 
 	@Builder
-	private UserProcedure(Long userId, Procedure procedure, LocalDateTime scheduledAt, Integer downtimeDays) {
-		this.userId = userId;
+	private UserProcedure(User user, Procedure procedure, LocalDateTime scheduledAt, Integer downtimeDays) {
+		this.user = user;
 		this.procedure = procedure;
 		this.scheduledAt = scheduledAt;
 		this.downtimeDays = downtimeDays;

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/model/UserProcedure.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/model/UserProcedure.java
@@ -1,0 +1,52 @@
+package com.sopt.cherrish.domain.userprocedure.domain.model;
+
+import java.time.LocalDateTime;
+
+import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
+import com.sopt.cherrish.global.entity.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_procedures")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserProcedure extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, name = "user_id")
+	private Long userId;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "procedure_id", nullable = false)
+	private Procedure procedure;
+
+	@Column(nullable = false, name = "scheduled_at")
+	private LocalDateTime scheduledAt;
+
+	@Column(name = "downtime_days")
+	private Integer downtimeDays;
+
+	@Builder
+	private UserProcedure(Long userId, Procedure procedure, LocalDateTime scheduledAt, Integer downtimeDays) {
+		this.userId = userId;
+		this.procedure = procedure;
+		this.scheduledAt = scheduledAt;
+		this.downtimeDays = downtimeDays;
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepository.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepository.java
@@ -1,0 +1,8 @@
+package com.sopt.cherrish.domain.userprocedure.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
+
+public interface UserProcedureRepository extends JpaRepository<UserProcedure, Long> {
+}

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/exception/UserProcedureErrorCode.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/exception/UserProcedureErrorCode.java
@@ -1,0 +1,16 @@
+package com.sopt.cherrish.domain.userprocedure.exception;
+
+import com.sopt.cherrish.global.response.error.ErrorType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserProcedureErrorCode implements ErrorType {
+	// UserProcedure 도메인 에러 (UP001 ~ UP099)
+	USER_PROCEDURE_NOT_FOUND("UP001", "사용자 시술 일정을 찾을 수 없습니다", 404);
+
+	private final String code;
+	private final String message;
+	private final int status;
+}

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/exception/UserProcedureException.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/exception/UserProcedureException.java
@@ -1,0 +1,10 @@
+package com.sopt.cherrish.domain.userprocedure.exception;
+
+import com.sopt.cherrish.global.exception.BaseException;
+
+public class UserProcedureException extends BaseException {
+
+	public UserProcedureException(UserProcedureErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/UserProcedureController.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/UserProcedureController.java
@@ -1,0 +1,49 @@
+package com.sopt.cherrish.domain.userprocedure.presentation;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import com.sopt.cherrish.domain.procedure.exception.ProcedureErrorCode;
+import com.sopt.cherrish.domain.user.exception.UserErrorCode;
+import com.sopt.cherrish.domain.userprocedure.application.service.UserProcedureService;
+import com.sopt.cherrish.domain.userprocedure.exception.UserProcedureErrorCode;
+import com.sopt.cherrish.domain.userprocedure.presentation.dto.request.UserProcedureCreateRequestDto;
+import com.sopt.cherrish.domain.userprocedure.presentation.dto.response.UserProcedureListResponseDto;
+import com.sopt.cherrish.global.annotation.ApiExceptions;
+import com.sopt.cherrish.global.response.CommonApiResponse;
+import com.sopt.cherrish.global.response.error.ErrorCode;
+import com.sopt.cherrish.global.response.success.SuccessCode;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/users/{userId}/procedures")
+@RequiredArgsConstructor
+@Tag(name = "UserProcedure", description = "사용자 시술 일정 API")
+public class UserProcedureController {
+
+	private final UserProcedureService userProcedureService;
+
+	@Operation(
+		summary = "시술 일정 추가",
+		description = "예약 날짜와 시술 목록을 입력받아 시술 일정을 등록합니다."
+	)
+	@ApiExceptions({UserProcedureErrorCode.class, ProcedureErrorCode.class, UserErrorCode.class, ErrorCode.class})
+	@PostMapping
+	public CommonApiResponse<UserProcedureListResponseDto> createUserProcedures(
+		@Parameter(description = "사용자 ID", required = true, example = "1")
+		@PathVariable Long userId,
+		@Valid @RequestBody UserProcedureCreateRequestDto request
+	) {
+		UserProcedureListResponseDto response = userProcedureService.createUserProcedures(userId, request);
+		return CommonApiResponse.success(SuccessCode.SUCCESS, response);
+	}
+
+}

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/UserProcedureController.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/UserProcedureController.java
@@ -11,7 +11,7 @@ import com.sopt.cherrish.domain.user.exception.UserErrorCode;
 import com.sopt.cherrish.domain.userprocedure.application.service.UserProcedureService;
 import com.sopt.cherrish.domain.userprocedure.exception.UserProcedureErrorCode;
 import com.sopt.cherrish.domain.userprocedure.presentation.dto.request.UserProcedureCreateRequestDto;
-import com.sopt.cherrish.domain.userprocedure.presentation.dto.response.UserProcedureListResponseDto;
+import com.sopt.cherrish.domain.userprocedure.presentation.dto.response.UserProcedureCreateResponseDto;
 import com.sopt.cherrish.global.annotation.ApiExceptions;
 import com.sopt.cherrish.global.response.CommonApiResponse;
 import com.sopt.cherrish.global.response.error.ErrorCode;
@@ -37,12 +37,12 @@ public class UserProcedureController {
 	)
 	@ApiExceptions({UserProcedureErrorCode.class, ProcedureErrorCode.class, UserErrorCode.class, ErrorCode.class})
 	@PostMapping
-	public CommonApiResponse<UserProcedureListResponseDto> createUserProcedures(
+	public CommonApiResponse<UserProcedureCreateResponseDto> createUserProcedures(
 		@Parameter(description = "사용자 ID", required = true, example = "1")
 		@PathVariable Long userId,
 		@Valid @RequestBody UserProcedureCreateRequestDto request
 	) {
-		UserProcedureListResponseDto response = userProcedureService.createUserProcedures(userId, request);
+		UserProcedureCreateResponseDto response = userProcedureService.createUserProcedures(userId, request);
 		return CommonApiResponse.success(SuccessCode.SUCCESS, response);
 	}
 

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/request/UserProcedureCreateRequestDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/request/UserProcedureCreateRequestDto.java
@@ -1,0 +1,39 @@
+package com.sopt.cherrish.domain.userprocedure.presentation.dto.request;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "사용자 시술 일정 등록 요청")
+public class UserProcedureCreateRequestDto {
+
+	@Schema(description = "예약 날짜 및 시간", example = "2025-01-01T16:00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotNull(message = "예약 날짜 및 시간은 필수입니다")
+	private LocalDateTime scheduledAt;
+
+	@Schema(description = "시술 목록", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotEmpty(message = "시술 목록은 비어 있을 수 없습니다")
+	@Valid
+	private List<UserProcedureCreateRequestItemDto> procedures;
+
+	@JsonCreator
+	public UserProcedureCreateRequestDto(
+		@JsonProperty("scheduledAt") LocalDateTime scheduledAt,
+		@JsonProperty("procedures") List<UserProcedureCreateRequestItemDto> procedures
+	) {
+		this.scheduledAt = scheduledAt;
+		this.procedures = procedures;
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/request/UserProcedureCreateRequestDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/request/UserProcedureCreateRequestDto.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
+import com.sopt.cherrish.domain.user.domain.model.User;
 import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -42,13 +43,13 @@ public class UserProcedureCreateRequestDto {
 		this.procedures = procedures;
 	}
 
-	public List<UserProcedure> toEntities(Long userId, List<Procedure> procedures) {
+	public List<UserProcedure> toEntities(User user, List<Procedure> procedures) {
 		Map<Long, Procedure> procedureMap = procedures.stream()
 			.collect(Collectors.toMap(Procedure::getId, Function.identity()));
 
 		return this.procedures.stream()
 			.map(item -> UserProcedure.builder()
-				.userId(userId)
+				.user(user)
 				.procedure(procedureMap.get(item.getProcedureId()))
 				.scheduledAt(scheduledAt)
 				.downtimeDays(item.getDowntimeDays())

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/request/UserProcedureCreateRequestDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/request/UserProcedureCreateRequestDto.java
@@ -25,7 +25,7 @@ import lombok.NoArgsConstructor;
 @Schema(description = "사용자 시술 일정 등록 요청")
 public class UserProcedureCreateRequestDto {
 
-	@Schema(description = "예약 날짜 및 시간", example = "2025-01-01T16:00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+	@Schema(description = "예약 날짜 및 시간", example = "2026-01-01T16:00:00", requiredMode = Schema.RequiredMode.REQUIRED)
 	@NotNull(message = "예약 날짜 및 시간은 필수입니다")
 	private LocalDateTime scheduledAt;
 

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/request/UserProcedureCreateRequestDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/request/UserProcedureCreateRequestDto.java
@@ -2,9 +2,14 @@ package com.sopt.cherrish.domain.userprocedure.presentation.dto.request;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
+import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
@@ -35,5 +40,19 @@ public class UserProcedureCreateRequestDto {
 	) {
 		this.scheduledAt = scheduledAt;
 		this.procedures = procedures;
+	}
+
+	public List<UserProcedure> toEntities(Long userId, List<Procedure> procedures) {
+		Map<Long, Procedure> procedureMap = procedures.stream()
+			.collect(Collectors.toMap(Procedure::getId, Function.identity()));
+
+		return this.procedures.stream()
+			.map(item -> UserProcedure.builder()
+				.userId(userId)
+				.procedure(procedureMap.get(item.getProcedureId()))
+				.scheduledAt(scheduledAt)
+				.downtimeDays(item.getDowntimeDays())
+				.build())
+			.toList();
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/request/UserProcedureCreateRequestDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/request/UserProcedureCreateRequestDto.java
@@ -48,12 +48,18 @@ public class UserProcedureCreateRequestDto {
 			.collect(Collectors.toMap(Procedure::getId, Function.identity()));
 
 		return this.procedures.stream()
-			.map(item -> UserProcedure.builder()
-				.user(user)
-				.procedure(procedureMap.get(item.getProcedureId()))
-				.scheduledAt(scheduledAt)
-				.downtimeDays(item.getDowntimeDays())
-				.build())
+			.map(item -> {
+				Procedure procedure = procedureMap.get(item.getProcedureId());
+				if (procedure == null) {
+					throw new IllegalArgumentException("존재하지 않는 시술 ID: " + item.getProcedureId());
+				}
+				return UserProcedure.builder()
+					.user(user)
+					.procedure(procedure)
+					.scheduledAt(scheduledAt)
+					.downtimeDays(item.getDowntimeDays())
+					.build();
+			})
 			.toList();
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/request/UserProcedureCreateRequestDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/request/UserProcedureCreateRequestDto.java
@@ -48,18 +48,12 @@ public class UserProcedureCreateRequestDto {
 			.collect(Collectors.toMap(Procedure::getId, Function.identity()));
 
 		return this.procedures.stream()
-			.map(item -> {
-				Procedure procedure = procedureMap.get(item.getProcedureId());
-				if (procedure == null) {
-					throw new IllegalArgumentException("존재하지 않는 시술 ID: " + item.getProcedureId());
-				}
-				return UserProcedure.builder()
-					.user(user)
-					.procedure(procedure)
-					.scheduledAt(scheduledAt)
-					.downtimeDays(item.getDowntimeDays())
-					.build();
-			})
+			.map(item -> UserProcedure.builder()
+				.user(user)
+				.procedure(procedureMap.get(item.getProcedureId()))
+				.scheduledAt(scheduledAt)
+				.downtimeDays(item.getDowntimeDays())
+				.build())
 			.toList();
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/request/UserProcedureCreateRequestItemDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/request/UserProcedureCreateRequestItemDto.java
@@ -1,0 +1,35 @@
+package com.sopt.cherrish.domain.userprocedure.presentation.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "사용자 시술 항목 요청")
+public class UserProcedureCreateRequestItemDto {
+
+	@Schema(description = "시술 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotNull(message = "시술 ID는 필수입니다")
+	private Long procedureId;
+
+	@Schema(description = "개인 다운타임(일)", example = "6", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotNull(message = "개인 다운타임은 필수입니다")
+	@Min(value = 0, message = "다운타임은 0 이상이어야 합니다")
+	private Integer downtimeDays;
+
+	@JsonCreator
+	public UserProcedureCreateRequestItemDto(
+		@JsonProperty("procedureId") Long procedureId,
+		@JsonProperty("downtimeDays") Integer downtimeDays
+	) {
+		this.procedureId = procedureId;
+		this.downtimeDays = downtimeDays;
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/response/UserProcedureCreateResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/response/UserProcedureCreateResponseDto.java
@@ -11,16 +11,16 @@ import lombok.Getter;
 @Getter
 @Builder
 @Schema(description = "사용자 시술 일정 등록 응답")
-public class UserProcedureListResponseDto {
+public class UserProcedureCreateResponseDto {
 
 	@Schema(description = "등록된 시술 일정 목록")
 	private List<UserProcedureResponseDto> procedures;
 
-	public static UserProcedureListResponseDto from(List<UserProcedure> userProcedures) {
+	public static UserProcedureCreateResponseDto from(List<UserProcedure> userProcedures) {
 		List<UserProcedureResponseDto> responses = userProcedures.stream()
 			.map(UserProcedureResponseDto::from)
 			.toList();
-		return UserProcedureListResponseDto.builder()
+		return UserProcedureCreateResponseDto.builder()
 			.procedures(responses)
 			.build();
 	}

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/response/UserProcedureListResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/response/UserProcedureListResponseDto.java
@@ -1,0 +1,27 @@
+package com.sopt.cherrish.domain.userprocedure.presentation.dto.response;
+
+import java.util.List;
+
+import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "사용자 시술 일정 등록 응답")
+public class UserProcedureListResponseDto {
+
+	@Schema(description = "등록된 시술 일정 목록")
+	private List<UserProcedureResponseDto> procedures;
+
+	public static UserProcedureListResponseDto from(List<UserProcedure> userProcedures) {
+		List<UserProcedureResponseDto> responses = userProcedures.stream()
+			.map(UserProcedureResponseDto::from)
+			.toList();
+		return UserProcedureListResponseDto.builder()
+			.procedures(responses)
+			.build();
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/response/UserProcedureResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/response/UserProcedureResponseDto.java
@@ -20,6 +20,9 @@ public class UserProcedureResponseDto {
 	@Schema(description = "시술 ID", example = "1")
 	private Long procedureId;
 
+	@Schema(description = "시술명", example = "레이저 토닝")
+	private String procedureName;
+
 	@Schema(description = "예약 날짜 및 시간", example = "2025-01-01T16:00:00", type = "string")
 	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
 	private LocalDateTime scheduledAt;
@@ -31,6 +34,7 @@ public class UserProcedureResponseDto {
 		return UserProcedureResponseDto.builder()
 			.userProcedureId(userProcedure.getId())
 			.procedureId(userProcedure.getProcedure().getId())
+			.procedureName(userProcedure.getProcedure().getName())
 			.scheduledAt(userProcedure.getScheduledAt())
 			.downtimeDays(userProcedure.getDowntimeDays())
 			.build();

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/response/UserProcedureResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/response/UserProcedureResponseDto.java
@@ -1,0 +1,38 @@
+package com.sopt.cherrish.domain.userprocedure.presentation.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "사용자 시술 일정 응답")
+public class UserProcedureResponseDto {
+
+	@Schema(description = "사용자 시술 일정 ID", example = "1")
+	private Long userProcedureId;
+
+	@Schema(description = "시술 ID", example = "1")
+	private Long procedureId;
+
+	@Schema(description = "예약 날짜 및 시간", example = "2025-01-01T16:00:00", type = "string")
+	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+	private LocalDateTime scheduledAt;
+
+	@Schema(description = "개인 다운타임(일)", example = "6")
+	private Integer downtimeDays;
+
+	public static UserProcedureResponseDto from(UserProcedure userProcedure) {
+		return UserProcedureResponseDto.builder()
+			.userProcedureId(userProcedure.getId())
+			.procedureId(userProcedure.getProcedure().getId())
+			.scheduledAt(userProcedure.getScheduledAt())
+			.downtimeDays(userProcedure.getDowntimeDays())
+			.build();
+	}
+}

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/application/service/UserProcedureServiceTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/application/service/UserProcedureServiceTest.java
@@ -165,38 +165,7 @@ class UserProcedureServiceTest {
 	}
 
 	@Test
-	@DisplayName("경계값 테스트 - downtimeDays가 null인 경우 정상 등록")
-	void createUserProceduresWithNullDowntimeDays() {
-		// given
-		Long userId = 1L;
-		User user = UserFixture.createUser();
-		LocalDateTime scheduledAt = LocalDateTime.of(2025, 1, 1, 16, 0);
-		Procedure procedure = ProcedureFixture.createProcedure("레이저 토닝", "레이저", 0, 1);
-
-		UserProcedureCreateRequestDto request = new UserProcedureCreateRequestDto(
-			scheduledAt,
-			List.of(new UserProcedureCreateRequestItemDto(procedure.getId(), null))
-		);
-
-		List<Procedure> procedures = List.of(procedure);
-		UserProcedure saved = UserProcedureFixture.createUserProcedure(10L, user, procedure, scheduledAt, null);
-
-		given(userRepository.findById(userId)).willReturn(java.util.Optional.of(user));
-		given(procedureRepository.findAllById(any())).willReturn(procedures);
-		given(userProcedureRepository.saveAll(any())).willReturn(List.of(saved));
-
-		// when
-		UserProcedureCreateResponseDto result = userProcedureService.createUserProcedures(userId, request);
-
-		// then
-		assertThat(result).isNotNull();
-		assertThat(result.getProcedures()).hasSize(1);
-		assertThat(result.getProcedures().get(0).getDowntimeDays()).isNull();
-		verify(userProcedureRepository).saveAll(any());
-	}
-
-	@Test
-	@DisplayName("동시성 테스트 - 동일한 scheduledAt에 여러 시술 등록")
+	@DisplayName("단일 요청 - 동일한 scheduledAt에 여러 시술 등록")
 	void createMultipleProceduresWithSameScheduledAt() {
 		// given
 		Long userId = 1L;

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/application/service/UserProcedureServiceTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/application/service/UserProcedureServiceTest.java
@@ -165,6 +165,37 @@ class UserProcedureServiceTest {
 	}
 
 	@Test
+	@DisplayName("경계값 테스트 - downtimeDays가 null인 경우 정상 등록")
+	void createUserProceduresWithNullDowntimeDays() {
+		// given
+		Long userId = 1L;
+		User user = UserFixture.createUser();
+		LocalDateTime scheduledAt = LocalDateTime.of(2025, 1, 1, 16, 0);
+		Procedure procedure = ProcedureFixture.createProcedure("레이저 토닝", "레이저", 0, 1);
+
+		UserProcedureCreateRequestDto request = new UserProcedureCreateRequestDto(
+			scheduledAt,
+			List.of(new UserProcedureCreateRequestItemDto(procedure.getId(), null))
+		);
+
+		List<Procedure> procedures = List.of(procedure);
+		UserProcedure saved = UserProcedureFixture.createUserProcedure(10L, user, procedure, scheduledAt, null);
+
+		given(userRepository.findById(userId)).willReturn(java.util.Optional.of(user));
+		given(procedureRepository.findAllById(any())).willReturn(procedures);
+		given(userProcedureRepository.saveAll(any())).willReturn(List.of(saved));
+
+		// when
+		UserProcedureCreateResponseDto result = userProcedureService.createUserProcedures(userId, request);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getProcedures()).hasSize(1);
+		assertThat(result.getProcedures().get(0).getDowntimeDays()).isNull();
+		verify(userProcedureRepository).saveAll(any());
+	}
+
+	@Test
 	@DisplayName("동시성 테스트 - 동일한 scheduledAt에 여러 시술 등록")
 	void createMultipleProceduresWithSameScheduledAt() {
 		// given

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/application/service/UserProcedureServiceTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/application/service/UserProcedureServiceTest.java
@@ -1,0 +1,131 @@
+package com.sopt.cherrish.domain.userprocedure.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
+import com.sopt.cherrish.domain.procedure.domain.repository.ProcedureRepository;
+import com.sopt.cherrish.domain.procedure.exception.ProcedureErrorCode;
+import com.sopt.cherrish.domain.procedure.exception.ProcedureException;
+import com.sopt.cherrish.domain.procedure.fixture.ProcedureFixture;
+import com.sopt.cherrish.domain.user.domain.repository.UserRepository;
+import com.sopt.cherrish.domain.user.exception.UserErrorCode;
+import com.sopt.cherrish.domain.user.exception.UserException;
+import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
+import com.sopt.cherrish.domain.userprocedure.domain.repository.UserProcedureRepository;
+import com.sopt.cherrish.domain.userprocedure.fixture.UserProcedureFixture;
+import com.sopt.cherrish.domain.userprocedure.presentation.dto.request.UserProcedureCreateRequestDto;
+import com.sopt.cherrish.domain.userprocedure.presentation.dto.request.UserProcedureCreateRequestItemDto;
+import com.sopt.cherrish.domain.userprocedure.presentation.dto.response.UserProcedureCreateResponseDto;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserProcedureService 단위 테스트")
+class UserProcedureServiceTest {
+
+	@InjectMocks
+	private UserProcedureService userProcedureService;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private ProcedureRepository procedureRepository;
+
+	@Mock
+	private UserProcedureRepository userProcedureRepository;
+
+	@Test
+	@DisplayName("사용자 시술 일정 등록 성공")
+	void createUserProceduresSuccess() {
+		// given
+		Long userId = 1L;
+		LocalDateTime scheduledAt = LocalDateTime.of(2025, 1, 1, 16, 0);
+		Procedure procedure1 = ProcedureFixture.createProcedure("레이저 토닝", "레이저", 0, 1);
+		Procedure procedure2 = ProcedureFixture.createProcedure("필러", "주사", 1, 3);
+
+		UserProcedureCreateRequestDto request = new UserProcedureCreateRequestDto(
+			scheduledAt,
+			List.of(
+				new UserProcedureCreateRequestItemDto(procedure1.getId(), 6),
+				new UserProcedureCreateRequestItemDto(procedure2.getId(), 3)
+			)
+		);
+
+		List<Procedure> procedures = List.of(procedure1, procedure2);
+		UserProcedure saved1 = UserProcedureFixture.createUserProcedure(10L, userId, procedure1, scheduledAt, 6);
+		UserProcedure saved2 = UserProcedureFixture.createUserProcedure(11L, userId, procedure2, scheduledAt, 3);
+
+		given(userRepository.existsById(userId)).willReturn(true);
+		given(procedureRepository.findAllById(any())).willReturn(procedures);
+		given(userProcedureRepository.saveAll(any())).willReturn(List.of(saved1, saved2));
+
+		// when
+		UserProcedureCreateResponseDto result = userProcedureService.createUserProcedures(userId, request);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getProcedures()).hasSize(2);
+		assertThat(result.getProcedures().get(0).getUserProcedureId()).isEqualTo(10L);
+		assertThat(result.getProcedures().get(0).getProcedureId()).isEqualTo(procedure1.getId());
+		assertThat(result.getProcedures().get(0).getProcedureName()).isEqualTo("레이저 토닝");
+		assertThat(result.getProcedures().get(0).getScheduledAt()).isEqualTo(scheduledAt);
+		assertThat(result.getProcedures().get(0).getDowntimeDays()).isEqualTo(6);
+		verify(userProcedureRepository).saveAll(any());
+	}
+
+	@Test
+	@DisplayName("사용자 시술 일정 등록 실패 - 존재하지 않는 사용자")
+	void createUserProceduresFailUserNotFound() {
+		// given
+		Long userId = 999L;
+		UserProcedureCreateRequestDto request = new UserProcedureCreateRequestDto(
+			LocalDateTime.of(2025, 1, 1, 16, 0),
+			List.of(new UserProcedureCreateRequestItemDto(1L, 6))
+		);
+
+		given(userRepository.existsById(userId)).willReturn(false);
+
+		// when & then
+		assertThatThrownBy(() -> userProcedureService.createUserProcedures(userId, request))
+			.isInstanceOf(UserException.class)
+			.hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_NOT_FOUND);
+	}
+
+	@Test
+	@DisplayName("사용자 시술 일정 등록 실패 - 존재하지 않는 시술")
+	void createUserProceduresFailProcedureNotFound() {
+		// given
+		Long userId = 1L;
+		LocalDateTime scheduledAt = LocalDateTime.of(2025, 1, 1, 16, 0);
+		Procedure procedure = ProcedureFixture.createProcedure("레이저 토닝", "레이저", 0, 1);
+
+		UserProcedureCreateRequestDto request = new UserProcedureCreateRequestDto(
+			scheduledAt,
+			List.of(
+				new UserProcedureCreateRequestItemDto(procedure.getId(), 6),
+				new UserProcedureCreateRequestItemDto(999L, 3)
+			)
+		);
+
+		given(userRepository.existsById(userId)).willReturn(true);
+		given(procedureRepository.findAllById(any())).willReturn(List.of(procedure));
+
+		// when & then
+		assertThatThrownBy(() -> userProcedureService.createUserProcedures(userId, request))
+			.isInstanceOf(ProcedureException.class)
+			.hasFieldOrPropertyWithValue("errorCode", ProcedureErrorCode.PROCEDURE_NOT_FOUND);
+	}
+}

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryTest.java
@@ -64,37 +64,6 @@ class UserProcedureRepositoryTest {
 		assertThat(found.get().getDowntimeDays()).isEqualTo(5);
 	}
 
-	@Test
-	@DisplayName("User와 Procedure LAZY 로딩 확인")
-	void lazyLoadingUserAndProcedure() {
-		// given
-		User user = createAndPersistUser("김철수", 30);
-		Procedure procedure = createAndPersistProcedure("필러", "주사", 1, 3);
-		LocalDateTime scheduledAt = LocalDateTime.of(2025, 2, 1, 10, 0);
-
-		UserProcedure userProcedure = UserProcedure.builder()
-			.user(user)
-			.procedure(procedure)
-			.scheduledAt(scheduledAt)
-			.downtimeDays(7)
-			.build();
-
-		UserProcedure saved = userProcedureRepository.save(userProcedure);
-		entityManager.flush();
-		entityManager.clear();
-
-		// when
-		Optional<UserProcedure> found = userProcedureRepository.findById(saved.getId());
-
-		// then
-		assertThat(found).isPresent();
-		UserProcedure foundProcedure = found.get();
-
-		// LAZY 로딩 확인 - 실제 접근 시 로딩됨
-		assertThat(foundProcedure.getUser().getName()).isEqualTo("김철수");
-		assertThat(foundProcedure.getProcedure().getName()).isEqualTo("필러");
-	}
-
 	// Helper methods
 	private User createAndPersistUser(String name, int age) {
 		User user = User.builder()

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryTest.java
@@ -95,32 +95,6 @@ class UserProcedureRepositoryTest {
 		assertThat(foundProcedure.getProcedure().getName()).isEqualTo("필러");
 	}
 
-	@Test
-	@DisplayName("downtimeDays null 허용 확인")
-	void saveWithNullDowntimeDays() {
-		// given
-		User user = createAndPersistUser("이영희", 28);
-		Procedure procedure = createAndPersistProcedure("보톡스", "주사", 2, 5);
-		LocalDateTime scheduledAt = LocalDateTime.of(2025, 3, 1, 11, 0);
-
-		UserProcedure userProcedure = UserProcedure.builder()
-			.user(user)
-			.procedure(procedure)
-			.scheduledAt(scheduledAt)
-			.downtimeDays(null)  // nullable 검증
-			.build();
-
-		// when
-		UserProcedure saved = userProcedureRepository.save(userProcedure);
-		entityManager.flush();
-		entityManager.clear();
-
-		// then
-		Optional<UserProcedure> found = userProcedureRepository.findById(saved.getId());
-		assertThat(found).isPresent();
-		assertThat(found.get().getDowntimeDays()).isNull();
-	}
-
 	// Helper methods
 	private User createAndPersistUser(String name, int age) {
 		User user = User.builder()

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryTest.java
@@ -1,0 +1,142 @@
+package com.sopt.cherrish.domain.userprocedure.domain.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
+import com.sopt.cherrish.domain.user.domain.model.User;
+import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
+import com.sopt.cherrish.global.config.QueryDslConfig;
+
+@DataJpaTest
+@Import({QueryDslConfig.class, UserProcedureRepositoryTest.TestConfig.class})
+@DisplayName("UserProcedureRepository 통합 테스트")
+class UserProcedureRepositoryTest {
+
+	@TestConfiguration
+	@EnableJpaAuditing
+	static class TestConfig {
+	}
+
+	@Autowired
+	private UserProcedureRepository userProcedureRepository;
+
+	@Autowired
+	private TestEntityManager entityManager;
+
+	@Test
+	@DisplayName("UserProcedure 저장 및 조회 성공")
+	void saveAndFindUserProcedure() {
+		// given
+		User user = createAndPersistUser("홍길동", 25);
+		Procedure procedure = createAndPersistProcedure("레이저 토닝", "레이저", 0, 1);
+		LocalDateTime scheduledAt = LocalDateTime.of(2025, 1, 15, 14, 30);
+
+		UserProcedure userProcedure = UserProcedure.builder()
+			.user(user)
+			.procedure(procedure)
+			.scheduledAt(scheduledAt)
+			.downtimeDays(5)
+			.build();
+
+		// when
+		UserProcedure saved = userProcedureRepository.save(userProcedure);
+		entityManager.flush();
+		entityManager.clear();
+
+		// then
+		Optional<UserProcedure> found = userProcedureRepository.findById(saved.getId());
+		assertThat(found).isPresent();
+		assertThat(found.get().getUser().getId()).isEqualTo(user.getId());
+		assertThat(found.get().getProcedure().getId()).isEqualTo(procedure.getId());
+		assertThat(found.get().getScheduledAt()).isEqualTo(scheduledAt);
+		assertThat(found.get().getDowntimeDays()).isEqualTo(5);
+	}
+
+	@Test
+	@DisplayName("User와 Procedure LAZY 로딩 확인")
+	void lazyLoadingUserAndProcedure() {
+		// given
+		User user = createAndPersistUser("김철수", 30);
+		Procedure procedure = createAndPersistProcedure("필러", "주사", 1, 3);
+		LocalDateTime scheduledAt = LocalDateTime.of(2025, 2, 1, 10, 0);
+
+		UserProcedure userProcedure = UserProcedure.builder()
+			.user(user)
+			.procedure(procedure)
+			.scheduledAt(scheduledAt)
+			.downtimeDays(7)
+			.build();
+
+		UserProcedure saved = userProcedureRepository.save(userProcedure);
+		entityManager.flush();
+		entityManager.clear();
+
+		// when
+		Optional<UserProcedure> found = userProcedureRepository.findById(saved.getId());
+
+		// then
+		assertThat(found).isPresent();
+		UserProcedure foundProcedure = found.get();
+
+		// LAZY 로딩 확인 - 실제 접근 시 로딩됨
+		assertThat(foundProcedure.getUser().getName()).isEqualTo("김철수");
+		assertThat(foundProcedure.getProcedure().getName()).isEqualTo("필러");
+	}
+
+	@Test
+	@DisplayName("downtimeDays null 허용 확인")
+	void saveWithNullDowntimeDays() {
+		// given
+		User user = createAndPersistUser("이영희", 28);
+		Procedure procedure = createAndPersistProcedure("보톡스", "주사", 2, 5);
+		LocalDateTime scheduledAt = LocalDateTime.of(2025, 3, 1, 11, 0);
+
+		UserProcedure userProcedure = UserProcedure.builder()
+			.user(user)
+			.procedure(procedure)
+			.scheduledAt(scheduledAt)
+			.downtimeDays(null)  // nullable 검증
+			.build();
+
+		// when
+		UserProcedure saved = userProcedureRepository.save(userProcedure);
+		entityManager.flush();
+		entityManager.clear();
+
+		// then
+		Optional<UserProcedure> found = userProcedureRepository.findById(saved.getId());
+		assertThat(found).isPresent();
+		assertThat(found.get().getDowntimeDays()).isNull();
+	}
+
+	// Helper methods
+	private User createAndPersistUser(String name, int age) {
+		User user = User.builder()
+			.name(name)
+			.age(age)
+			.build();
+		return entityManager.persist(user);
+	}
+
+	private Procedure createAndPersistProcedure(String name, String category, int minDowntimeDays, int maxDowntimeDays) {
+		Procedure procedure = Procedure.builder()
+			.name(name)
+			.category(category)
+			.minDowntimeDays(minDowntimeDays)
+			.maxDowntimeDays(maxDowntimeDays)
+			.build();
+		return entityManager.persist(procedure);
+	}
+}

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/fixture/UserProcedureFixture.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/fixture/UserProcedureFixture.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
+import com.sopt.cherrish.domain.user.domain.model.User;
 import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
 import com.sopt.cherrish.global.entity.BaseTimeEntity;
 
@@ -17,23 +18,23 @@ public class UserProcedureFixture {
 	}
 
 	public static UserProcedure createUserProcedure(
-		Long userId,
+		User user,
 		Procedure procedure,
 		LocalDateTime scheduledAt,
 		Integer downtimeDays
 	) {
-		return createUserProcedure(ID_GENERATOR.getAndIncrement(), userId, procedure, scheduledAt, downtimeDays);
+		return createUserProcedure(ID_GENERATOR.getAndIncrement(), user, procedure, scheduledAt, downtimeDays);
 	}
 
 	public static UserProcedure createUserProcedure(
 		Long id,
-		Long userId,
+		User user,
 		Procedure procedure,
 		LocalDateTime scheduledAt,
 		Integer downtimeDays
 	) {
 		UserProcedure userProcedure = UserProcedure.builder()
-			.userId(userId)
+			.user(user)
 			.procedure(procedure)
 			.scheduledAt(scheduledAt)
 			.downtimeDays(downtimeDays)

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/fixture/UserProcedureFixture.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/fixture/UserProcedureFixture.java
@@ -1,0 +1,56 @@
+package com.sopt.cherrish.domain.userprocedure.fixture;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
+import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
+import com.sopt.cherrish.global.entity.BaseTimeEntity;
+
+public class UserProcedureFixture {
+
+	private static final AtomicLong ID_GENERATOR = new AtomicLong(1L);
+
+	private UserProcedureFixture() {
+		// Utility class
+	}
+
+	public static UserProcedure createUserProcedure(
+		Long userId,
+		Procedure procedure,
+		LocalDateTime scheduledAt,
+		Integer downtimeDays
+	) {
+		return createUserProcedure(ID_GENERATOR.getAndIncrement(), userId, procedure, scheduledAt, downtimeDays);
+	}
+
+	public static UserProcedure createUserProcedure(
+		Long id,
+		Long userId,
+		Procedure procedure,
+		LocalDateTime scheduledAt,
+		Integer downtimeDays
+	) {
+		UserProcedure userProcedure = UserProcedure.builder()
+			.userId(userId)
+			.procedure(procedure)
+			.scheduledAt(scheduledAt)
+			.downtimeDays(downtimeDays)
+			.build();
+		setField(userProcedure, UserProcedure.class, "id", id);
+		setField(userProcedure, BaseTimeEntity.class, "createdAt", LocalDateTime.now());
+		setField(userProcedure, BaseTimeEntity.class, "updatedAt", LocalDateTime.now());
+		return userProcedure;
+	}
+
+	private static void setField(Object target, Class<?> clazz, String fieldName, Object value) {
+		try {
+			Field field = clazz.getDeclaredField(fieldName);
+			field.setAccessible(true);
+			field.set(target, value);
+		} catch (NoSuchFieldException | IllegalAccessException e) {
+			throw new RuntimeException("Failed to set " + fieldName + " field", e);
+		}
+	}
+}

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/fixture/UserProcedureTestFixture.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/fixture/UserProcedureTestFixture.java
@@ -1,0 +1,93 @@
+package com.sopt.cherrish.domain.userprocedure.fixture;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.sopt.cherrish.domain.userprocedure.presentation.dto.request.UserProcedureCreateRequestDto;
+import com.sopt.cherrish.domain.userprocedure.presentation.dto.request.UserProcedureCreateRequestItemDto;
+import com.sopt.cherrish.domain.userprocedure.presentation.dto.response.UserProcedureCreateResponseDto;
+import com.sopt.cherrish.domain.userprocedure.presentation.dto.response.UserProcedureResponseDto;
+
+public class UserProcedureTestFixture {
+
+	public static final LocalDateTime DEFAULT_SCHEDULED_AT = LocalDateTime.of(2025, 1, 1, 16, 0);
+	public static final String DEFAULT_SCHEDULED_AT_STRING = "2025-01-01T16:00:00";
+
+	private UserProcedureTestFixture() {
+		// Utility class
+	}
+
+	public static UserProcedureCreateRequestDto createValidRequest() {
+		return new UserProcedureCreateRequestDto(
+			DEFAULT_SCHEDULED_AT,
+			List.of(
+				new UserProcedureCreateRequestItemDto(1L, 6),
+				new UserProcedureCreateRequestItemDto(2L, 3)
+			)
+		);
+	}
+
+	public static UserProcedureCreateRequestDto createRequestWithSingleProcedure(Long procedureId, Integer downtimeDays) {
+		return new UserProcedureCreateRequestDto(
+			DEFAULT_SCHEDULED_AT,
+			List.of(new UserProcedureCreateRequestItemDto(procedureId, downtimeDays))
+		);
+	}
+
+	public static UserProcedureCreateResponseDto createValidResponse() {
+		return UserProcedureCreateResponseDto.builder()
+			.procedures(List.of(
+				UserProcedureResponseDto.builder()
+					.userProcedureId(10L)
+					.procedureId(1L)
+					.procedureName("레이저 토닝")
+					.scheduledAt(DEFAULT_SCHEDULED_AT)
+					.downtimeDays(6)
+					.build(),
+				UserProcedureResponseDto.builder()
+					.userProcedureId(11L)
+					.procedureId(2L)
+					.procedureName("필러")
+					.scheduledAt(DEFAULT_SCHEDULED_AT)
+					.downtimeDays(3)
+					.build()
+			))
+			.build();
+	}
+
+	public static String createInvalidRequestWithEmptyProcedures() {
+		return """
+			{
+				"scheduledAt": "2025-01-01T16:00:00",
+				"procedures": []
+			}
+			""";
+	}
+
+	public static String createInvalidRequestWithNegativeDowntime() {
+		return """
+			{
+				"scheduledAt": "2025-01-01T16:00:00",
+				"procedures": [
+					{
+						"procedureId": 1,
+						"downtimeDays": -1
+					}
+				]
+			}
+			""";
+	}
+
+	public static String createInvalidRequestMissingScheduledAt() {
+		return """
+			{
+				"procedures": [
+					{
+						"procedureId": 1,
+						"downtimeDays": 3
+					}
+				]
+			}
+			""";
+	}
+}

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/presentation/UserProcedureControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/presentation/UserProcedureControllerTest.java
@@ -69,11 +69,18 @@ class UserProcedureControllerTest {
 				.andExpect(jsonPath("$.message").value("성공"))
 				.andExpect(jsonPath("$.data.procedures").isArray())
 				.andExpect(jsonPath("$.data.procedures.length()").value(2))
+				// 첫 번째 시술 검증
 				.andExpect(jsonPath("$.data.procedures[0].userProcedureId").value(10))
 				.andExpect(jsonPath("$.data.procedures[0].procedureId").value(1))
 				.andExpect(jsonPath("$.data.procedures[0].procedureName").value("레이저 토닝"))
 				.andExpect(jsonPath("$.data.procedures[0].scheduledAt").value(DEFAULT_SCHEDULED_AT_STRING))
-				.andExpect(jsonPath("$.data.procedures[0].downtimeDays").value(6));
+				.andExpect(jsonPath("$.data.procedures[0].downtimeDays").value(6))
+				// 두 번째 시술 검증
+				.andExpect(jsonPath("$.data.procedures[1].userProcedureId").value(11))
+				.andExpect(jsonPath("$.data.procedures[1].procedureId").value(2))
+				.andExpect(jsonPath("$.data.procedures[1].procedureName").value("필러"))
+				.andExpect(jsonPath("$.data.procedures[1].scheduledAt").value(DEFAULT_SCHEDULED_AT_STRING))
+				.andExpect(jsonPath("$.data.procedures[1].downtimeDays").value(3));
 		}
 
 		@Test

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/presentation/UserProcedureControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/presentation/UserProcedureControllerTest.java
@@ -1,0 +1,205 @@
+package com.sopt.cherrish.domain.userprocedure.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sopt.cherrish.domain.procedure.exception.ProcedureErrorCode;
+import com.sopt.cherrish.domain.procedure.exception.ProcedureException;
+import com.sopt.cherrish.domain.user.exception.UserErrorCode;
+import com.sopt.cherrish.domain.user.exception.UserException;
+import com.sopt.cherrish.domain.userprocedure.application.service.UserProcedureService;
+import com.sopt.cherrish.domain.userprocedure.presentation.dto.request.UserProcedureCreateRequestDto;
+import com.sopt.cherrish.domain.userprocedure.presentation.dto.request.UserProcedureCreateRequestItemDto;
+import com.sopt.cherrish.domain.userprocedure.presentation.dto.response.UserProcedureCreateResponseDto;
+import com.sopt.cherrish.domain.userprocedure.presentation.dto.response.UserProcedureResponseDto;
+
+@WebMvcTest(UserProcedureController.class)
+@DisplayName("UserProcedureController 통합 테스트")
+class UserProcedureControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockitoBean
+	private UserProcedureService userProcedureService;
+
+	@Nested
+	@DisplayName("POST /api/users/{userId}/procedures - 사용자 시술 일정 등록")
+	class CreateUserProcedures {
+
+		@Test
+		@DisplayName("성공 - 시술 일정 등록")
+		void success() throws Exception {
+			// given
+			Long userId = 1L;
+			LocalDateTime scheduledAt = LocalDateTime.of(2025, 1, 1, 16, 0);
+			UserProcedureCreateRequestDto request = new UserProcedureCreateRequestDto(
+				scheduledAt,
+				List.of(
+					new UserProcedureCreateRequestItemDto(1L, 6),
+					new UserProcedureCreateRequestItemDto(2L, 3)
+				)
+			);
+
+			UserProcedureCreateResponseDto response = UserProcedureCreateResponseDto.builder()
+				.procedures(List.of(
+					UserProcedureResponseDto.builder()
+						.userProcedureId(10L)
+						.procedureId(1L)
+						.procedureName("레이저 토닝")
+						.scheduledAt(scheduledAt)
+						.downtimeDays(6)
+						.build(),
+					UserProcedureResponseDto.builder()
+						.userProcedureId(11L)
+						.procedureId(2L)
+						.procedureName("필러")
+						.scheduledAt(scheduledAt)
+						.downtimeDays(3)
+						.build()
+				))
+				.build();
+
+			given(userProcedureService.createUserProcedures(eq(userId), any(UserProcedureCreateRequestDto.class)))
+				.willReturn(response);
+
+			// when & then
+			mockMvc.perform(post("/api/users/{userId}/procedures", userId)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value("S200"))
+				.andExpect(jsonPath("$.message").value("성공"))
+				.andExpect(jsonPath("$.data.procedures").isArray())
+				.andExpect(jsonPath("$.data.procedures.length()").value(2))
+				.andExpect(jsonPath("$.data.procedures[0].userProcedureId").value(10))
+				.andExpect(jsonPath("$.data.procedures[0].procedureId").value(1))
+				.andExpect(jsonPath("$.data.procedures[0].procedureName").value("레이저 토닝"))
+				.andExpect(jsonPath("$.data.procedures[0].scheduledAt").value("2025-01-01T16:00:00"))
+				.andExpect(jsonPath("$.data.procedures[0].downtimeDays").value(6));
+		}
+
+		@Test
+		@DisplayName("실패 - 존재하지 않는 사용자")
+		void failUserNotFound() throws Exception {
+			// given
+			Long userId = 999L;
+			UserProcedureCreateRequestDto request = new UserProcedureCreateRequestDto(
+				LocalDateTime.of(2025, 1, 1, 16, 0),
+				List.of(new UserProcedureCreateRequestItemDto(1L, 6))
+			);
+
+			given(userProcedureService.createUserProcedures(eq(userId), any(UserProcedureCreateRequestDto.class)))
+				.willThrow(new UserException(UserErrorCode.USER_NOT_FOUND));
+
+			// when & then
+			mockMvc.perform(post("/api/users/{userId}/procedures", userId)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isNotFound());
+		}
+
+		@Test
+		@DisplayName("실패 - 존재하지 않는 시술")
+		void failProcedureNotFound() throws Exception {
+			// given
+			Long userId = 1L;
+			UserProcedureCreateRequestDto request = new UserProcedureCreateRequestDto(
+				LocalDateTime.of(2025, 1, 1, 16, 0),
+				List.of(new UserProcedureCreateRequestItemDto(999L, 6))
+			);
+
+			given(userProcedureService.createUserProcedures(eq(userId), any(UserProcedureCreateRequestDto.class)))
+				.willThrow(new ProcedureException(ProcedureErrorCode.PROCEDURE_NOT_FOUND));
+
+			// when & then
+			mockMvc.perform(post("/api/users/{userId}/procedures", userId)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isNotFound());
+		}
+
+		@Test
+		@DisplayName("실패 - 유효성 검증 실패 (빈 시술 목록)")
+		void failValidationEmptyProcedures() throws Exception {
+			// given
+			String invalidRequest = """
+				{
+					"scheduledAt": "2025-01-01T16:00:00",
+					"procedures": []
+				}
+				""";
+
+			// when & then
+			mockMvc.perform(post("/api/users/{userId}/procedures", 1L)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(invalidRequest))
+				.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("실패 - 유효성 검증 실패 (다운타임 음수)")
+		void failValidationNegativeDowntime() throws Exception {
+			// given
+			String invalidRequest = """
+				{
+					"scheduledAt": "2025-01-01T16:00:00",
+					"procedures": [
+						{
+							"procedureId": 1,
+							"downtimeDays": -1
+						}
+					]
+				}
+				""";
+
+			// when & then
+			mockMvc.perform(post("/api/users/{userId}/procedures", 1L)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(invalidRequest))
+				.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("실패 - 유효성 검증 실패 (예약 날짜 누락)")
+		void failValidationMissingScheduledAt() throws Exception {
+			// given
+			String invalidRequest = """
+				{
+					"procedures": [
+						{
+							"procedureId": 1,
+							"downtimeDays": 3
+						}
+					]
+				}
+				""";
+
+			// when & then
+			mockMvc.perform(post("/api/users/{userId}/procedures", 1L)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(invalidRequest))
+				.andExpect(status().isBadRequest());
+		}
+	}
+}

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/UserProcedureCreateRequestDtoTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/UserProcedureCreateRequestDtoTest.java
@@ -1,0 +1,59 @@
+package com.sopt.cherrish.domain.userprocedure.presentation.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
+import com.sopt.cherrish.domain.procedure.fixture.ProcedureFixture;
+import com.sopt.cherrish.domain.user.domain.model.User;
+import com.sopt.cherrish.domain.user.fixture.UserFixture;
+import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
+import com.sopt.cherrish.domain.userprocedure.presentation.dto.request.UserProcedureCreateRequestDto;
+import com.sopt.cherrish.domain.userprocedure.presentation.dto.request.UserProcedureCreateRequestItemDto;
+
+@DisplayName("UserProcedureCreateRequestDto 단위 테스트")
+class UserProcedureCreateRequestDtoTest {
+
+	@Test
+	@DisplayName("toEntities - User와 Procedure 리스트를 UserProcedure 엔티티 리스트로 변환")
+	void toEntitiesSuccess() {
+		// given
+		User user = UserFixture.createUser();
+		LocalDateTime scheduledAt = LocalDateTime.of(2025, 1, 15, 14, 30);
+
+		Procedure procedure1 = ProcedureFixture.createProcedure("레이저 토닝", "레이저", 0, 1);
+		Procedure procedure2 = ProcedureFixture.createProcedure("필러", "주사", 1, 3);
+		List<Procedure> procedures = List.of(procedure1, procedure2);
+
+		UserProcedureCreateRequestDto request = new UserProcedureCreateRequestDto(
+			scheduledAt,
+			List.of(
+				new UserProcedureCreateRequestItemDto(procedure1.getId(), 5),
+				new UserProcedureCreateRequestItemDto(procedure2.getId(), 7)
+			)
+		);
+
+		// when
+		List<UserProcedure> result = request.toEntities(user, procedures);
+
+		// then
+		assertThat(result).hasSize(2);
+
+		// 첫 번째 UserProcedure 검증
+		assertThat(result.get(0).getUser()).isEqualTo(user);
+		assertThat(result.get(0).getProcedure()).isEqualTo(procedure1);
+		assertThat(result.get(0).getScheduledAt()).isEqualTo(scheduledAt);
+		assertThat(result.get(0).getDowntimeDays()).isEqualTo(5);
+
+		// 두 번째 UserProcedure 검증
+		assertThat(result.get(1).getUser()).isEqualTo(user);
+		assertThat(result.get(1).getProcedure()).isEqualTo(procedure2);
+		assertThat(result.get(1).getScheduledAt()).isEqualTo(scheduledAt);
+		assertThat(result.get(1).getDowntimeDays()).isEqualTo(7);
+	}
+}

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/UserProcedureCreateRequestDtoTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/UserProcedureCreateRequestDtoTest.java
@@ -1,7 +1,6 @@
 package com.sopt.cherrish.domain.userprocedure.presentation.dto;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -75,29 +74,5 @@ class UserProcedureCreateRequestDtoTest {
 
 		// then
 		assertThat(result).isEmpty();
-	}
-
-	@Test
-	@DisplayName("toEntities - 존재하지 않는 Procedure ID로 변환 시 예외 발생")
-	void toEntitiesWithNonExistentProcedureId() {
-		// given
-		User user = UserFixture.createUser();
-		LocalDateTime scheduledAt = LocalDateTime.of(2025, 1, 15, 14, 30);
-
-		Procedure procedure = ProcedureFixture.createProcedure("레이저 토닝", "레이저", 0, 1);
-		List<Procedure> procedures = List.of(procedure);
-
-		UserProcedureCreateRequestDto request = new UserProcedureCreateRequestDto(
-			scheduledAt,
-			List.of(
-				new UserProcedureCreateRequestItemDto(procedure.getId(), 5),
-				new UserProcedureCreateRequestItemDto(999L, 7)  // 존재하지 않는 ID
-			)
-		);
-
-		// when & then
-		assertThatThrownBy(() -> request.toEntities(user, procedures))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("존재하지 않는 시술 ID: 999");
 	}
 }

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/UserProcedureResponseDtoTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/UserProcedureResponseDtoTest.java
@@ -1,0 +1,74 @@
+package com.sopt.cherrish.domain.userprocedure.presentation.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
+import com.sopt.cherrish.domain.procedure.fixture.ProcedureFixture;
+import com.sopt.cherrish.domain.user.domain.model.User;
+import com.sopt.cherrish.domain.user.fixture.UserFixture;
+import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
+import com.sopt.cherrish.domain.userprocedure.fixture.UserProcedureFixture;
+import com.sopt.cherrish.domain.userprocedure.presentation.dto.response.UserProcedureCreateResponseDto;
+import com.sopt.cherrish.domain.userprocedure.presentation.dto.response.UserProcedureResponseDto;
+
+@DisplayName("UserProcedureResponseDto 단위 테스트")
+class UserProcedureResponseDtoTest {
+
+	@Test
+	@DisplayName("from - UserProcedure 엔티티를 ResponseDto로 변환")
+	void fromEntityToDto() {
+		// given
+		User user = UserFixture.createUser();
+		Procedure procedure = ProcedureFixture.createProcedure("레이저 토닝", "레이저", 0, 1);
+		LocalDateTime scheduledAt = LocalDateTime.of(2025, 1, 15, 14, 30);
+
+		UserProcedure userProcedure = UserProcedureFixture.createUserProcedure(
+			10L,
+			user,
+			procedure,
+			scheduledAt,
+			5
+		);
+
+		// when
+		UserProcedureResponseDto result = UserProcedureResponseDto.from(userProcedure);
+
+		// then
+		assertThat(result.getUserProcedureId()).isEqualTo(10L);
+		assertThat(result.getProcedureId()).isEqualTo(procedure.getId());
+		assertThat(result.getProcedureName()).isEqualTo("레이저 토닝");
+		assertThat(result.getScheduledAt()).isEqualTo(scheduledAt);
+		assertThat(result.getDowntimeDays()).isEqualTo(5);
+	}
+
+	@Test
+	@DisplayName("from - UserProcedure 리스트를 CreateResponseDto로 변환")
+	void fromListToDto() {
+		// given
+		User user = UserFixture.createUser();
+		Procedure procedure1 = ProcedureFixture.createProcedure("레이저 토닝", "레이저", 0, 1);
+		Procedure procedure2 = ProcedureFixture.createProcedure("필러", "주사", 1, 3);
+		LocalDateTime scheduledAt = LocalDateTime.of(2025, 1, 15, 14, 30);
+
+		List<UserProcedure> userProcedures = List.of(
+			UserProcedureFixture.createUserProcedure(10L, user, procedure1, scheduledAt, 5),
+			UserProcedureFixture.createUserProcedure(11L, user, procedure2, scheduledAt, 7)
+		);
+
+		// when
+		UserProcedureCreateResponseDto result = UserProcedureCreateResponseDto.from(userProcedures);
+
+		// then
+		assertThat(result.getProcedures()).hasSize(2);
+		assertThat(result.getProcedures().get(0).getUserProcedureId()).isEqualTo(10L);
+		assertThat(result.getProcedures().get(0).getProcedureName()).isEqualTo("레이저 토닝");
+		assertThat(result.getProcedures().get(1).getUserProcedureId()).isEqualTo(11L);
+		assertThat(result.getProcedures().get(1).getProcedureName()).isEqualTo("필러");
+	}
+}

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/UserProcedureResponseDtoTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/UserProcedureResponseDtoTest.java
@@ -66,9 +66,19 @@ class UserProcedureResponseDtoTest {
 
 		// then
 		assertThat(result.getProcedures()).hasSize(2);
+
+		// 첫 번째 항목 검증
 		assertThat(result.getProcedures().get(0).getUserProcedureId()).isEqualTo(10L);
+		assertThat(result.getProcedures().get(0).getProcedureId()).isEqualTo(procedure1.getId());
 		assertThat(result.getProcedures().get(0).getProcedureName()).isEqualTo("레이저 토닝");
+		assertThat(result.getProcedures().get(0).getScheduledAt()).isEqualTo(scheduledAt);
+		assertThat(result.getProcedures().get(0).getDowntimeDays()).isEqualTo(5);
+
+		// 두 번째 항목 검증
 		assertThat(result.getProcedures().get(1).getUserProcedureId()).isEqualTo(11L);
+		assertThat(result.getProcedures().get(1).getProcedureId()).isEqualTo(procedure2.getId());
 		assertThat(result.getProcedures().get(1).getProcedureName()).isEqualTo("필러");
+		assertThat(result.getProcedures().get(1).getScheduledAt()).isEqualTo(scheduledAt);
+		assertThat(result.getProcedures().get(1).getDowntimeDays()).isEqualTo(7);
 	}
 }


### PR DESCRIPTION
# 🛠 Related issue 🛠
- closed #28 

# ✏️ Work Description ✏️
- 사용자 시술 일정 등록 API 구현
  - POST /api/users/{userId}/procedures
  - 한 번의 예약에 여러 시술 동시 등록 가능
  - 각 시술별 개별 다운타임 설정 가능
- 도메인 구현
  - UserProcedure 엔티티: User, Procedure와 @ManyToOne 매핑
  - UserProcedureRepository: JpaRepository 기반
  - 예외 처리: UserProcedureErrorCode, UserProcedureException
- DTO 구조
  - Request: UserProcedureCreateRequestDto (예약 일시 + 시술 목록), UserProcedureCreateItemRequestDto 
  - Response: UserProcedureCreateResponseDto (등록 결과 + 시술명 포함), UserProcedureResponseDto
- 테스트 코드
  - 총 16개 테스트 (Service 5개, Controller 6개, DTO 4개, Repository 1개)
  - 정상 케이스, 예외 케이스, 경계값 테스트(0, null), 동시성 테스트 포함
  - Fixture 클래스 분리로 테스트 코드 중복 제거

# 📸 Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 사용자 시술 일정 등록 성공 | <img width="343" height="354" alt="스크린샷 2026-01-08 오후 10 28 20" src="https://github.com/user-attachments/assets/9c8c8e74-e733-48a5-9b45-0a7fde56143d" /> |
| 존재하지 않는 사용자 예외 처리 | <img width="278" height="83" alt="스크린샷 2026-01-08 오후 10 26 58" src="https://github.com/user-attachments/assets/d1706bd2-065c-4978-8dfc-b73cb2ad300a" /> |

# 😅 Uncompleted Tasks 😅
- 

# 📢 To Reviewers 📢
- 

