### PR TITLE
[Refactor]API userId 전달 방식 변경

### DIFF
--- a/src/main/java/com/sopt/cherrish/domain/challenge/core/presentation/ChallengeController.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/core/presentation/ChallengeController.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -40,47 +41,47 @@ public class ChallengeController {
 	private final ChallengeQueryFacade challengeQueryFacade;
 	private final ChallengeRoutineService challengeRoutineService;
 
-	// TODO: Spring Security 추가 시 PathVariable userId 제거하고 @AuthenticationPrincipal 사용
+	// TODO: Spring Security 추가 시 RequestHeader userId 제거하고 @AuthenticationPrincipal 사용
 	@Operation(
 		summary = "챌린지 생성",
 		description = "홈케어 루틴 ID와 루틴명 리스트를 입력받아 7일 챌린지를 생성합니다."
 	)
 	@ApiExceptions({ChallengeErrorCode.class, UserErrorCode.class, ErrorCode.class})
-	@PostMapping("/{userId}")
+	@PostMapping
 	public CommonApiResponse<ChallengeCreateResponseDto> createChallenge(
-		@Parameter(description = "사용자 ID", required = true, example = "1")
-		@PathVariable Long userId,
+		@Parameter(description = "사용자 ID (X-User-Id 헤더)", required = true, example = "1")
+		@RequestHeader("X-User-Id") Long userId,
 		@Valid @RequestBody ChallengeCreateRequestDto request
 	) {
 		ChallengeCreateResponseDto response = challengeCreationFacade.createChallenge(userId, request);
 		return CommonApiResponse.success(SuccessCode.SUCCESS, response);
 	}
 
-	// TODO: Spring Security 추가 시 PathVariable userId 제거하고 @AuthenticationPrincipal 사용
+	// TODO: Spring Security 추가 시 RequestHeader userId 제거하고 @AuthenticationPrincipal 사용
 	@Operation(
 		summary = "활성 챌린지 조회",
 		description = "사용자의 활성 챌린지와 진행 상황, 오늘의 루틴을 조회합니다."
 	)
 	@ApiExceptions({ChallengeErrorCode.class, UserErrorCode.class, ErrorCode.class})
-	@GetMapping("/{userId}")
+	@GetMapping
 	public CommonApiResponse<ChallengeDetailResponseDto> getActiveChallenge(
-		@Parameter(description = "사용자 ID", required = true, example = "1")
-		@PathVariable Long userId
+		@Parameter(description = "사용자 ID (X-User-Id 헤더)", required = true, example = "1")
+		@RequestHeader("X-User-Id") Long userId
 	) {
 		ChallengeDetailResponseDto response = challengeQueryFacade.getActiveChallengeDetail(userId);
 		return CommonApiResponse.success(SuccessCode.SUCCESS, response);
 	}
 
-	// TODO: Spring Security 추가 시 PathVariable userId 제거하고 @AuthenticationPrincipal 사용
+	// TODO: Spring Security 추가 시 RequestHeader userId 제거하고 @AuthenticationPrincipal 사용
 	@Operation(
 		summary = "루틴 완료 토글",
 		description = "루틴의 완료 상태를 토글합니다. 완료 시 통계와 체리 레벨이 자동 업데이트됩니다."
 	)
 	@ApiExceptions({ChallengeErrorCode.class, UserErrorCode.class, ErrorCode.class})
-	@PatchMapping("/{userId}/routines/{routineId}")
+	@PatchMapping("/routines/{routineId}")
 	public CommonApiResponse<RoutineCompletionResponseDto> toggleRoutineCompletion(
-		@Parameter(description = "사용자 ID", required = true, example = "1")
-		@PathVariable Long userId,
+		@Parameter(description = "사용자 ID (X-User-Id 헤더)", required = true, example = "1")
+		@RequestHeader("X-User-Id") Long userId,
 		@Parameter(description = "루틴 ID", required = true, example = "1")
 		@PathVariable Long routineId
 	) {
@@ -89,17 +90,17 @@ public class ChallengeController {
 		return CommonApiResponse.success(SuccessCode.SUCCESS, response);
 	}
 
-	// TODO: Spring Security 추가 시 PathVariable userId 제거하고 @AuthenticationPrincipal 사용
+	// TODO: Spring Security 추가 시 RequestHeader userId 제거하고 @AuthenticationPrincipal 사용
 	@Operation(
 		summary = "루틴 일괄 업데이트",
 		description = "여러 루틴의 완료 상태를 한 번에 업데이트합니다. "
 			+ "All or Nothing 방식으로 동작하여 하나라도 실패하면 전체 롤백됩니다."
 	)
 	@ApiExceptions({ChallengeErrorCode.class, UserErrorCode.class, ErrorCode.class})
-	@PatchMapping("/{userId}/routines")
+	@PatchMapping("/routines")
 	public CommonApiResponse<RoutineBatchUpdateResponseDto> updateMultipleRoutines(
-		@Parameter(description = "사용자 ID", required = true, example = "1")
-		@PathVariable Long userId,
+		@Parameter(description = "사용자 ID (X-User-Id 헤더)", required = true, example = "1")
+		@RequestHeader("X-User-Id") Long userId,
 		@Valid @RequestBody RoutineUpdateRequestDto request
 	) {
 		RoutineBatchUpdateResponseDto response = challengeRoutineService.updateMultipleRoutines(userId, request);

--- a/src/main/java/com/sopt/cherrish/domain/user/presentation/UserController.java
+++ b/src/main/java/com/sopt/cherrish/domain/user/presentation/UserController.java
@@ -3,8 +3,8 @@ package com.sopt.cherrish.domain.user.presentation;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -36,12 +36,12 @@ public class UserController {
 		description = "사용자 ID로 사용자 정보를 조회합니다."
 	)
 	@ApiExceptions({UserErrorCode.class, ErrorCode.class})
-	@GetMapping("/{id}")
+	@GetMapping
 	public CommonApiResponse<UserResponseDto> getUser(
-		@Parameter(description = "사용자 ID", required = true, example = "1")
-		@PathVariable Long id
+		@Parameter(description = "사용자 ID (X-User-Id 헤더)", required = true, example = "1")
+		@RequestHeader("X-User-Id") Long userId
 	) {
-		UserResponseDto response = userService.getUser(id);
+		UserResponseDto response = userService.getUser(userId);
 		return CommonApiResponse.success(SuccessCode.SUCCESS, response);
 	}
 
@@ -50,13 +50,13 @@ public class UserController {
 		description = "사용자의 이름 또는 나이를 수정합니다. 제공된 필드만 수정됩니다."
 	)
 	@ApiExceptions({UserErrorCode.class, ErrorCode.class})
-	@PatchMapping("/{id}")
+	@PatchMapping
 	public CommonApiResponse<UserResponseDto> updateUser(
-		@Parameter(description = "사용자 ID", required = true, example = "1")
-		@PathVariable Long id,
+		@Parameter(description = "사용자 ID (X-User-Id 헤더)", required = true, example = "1")
+		@RequestHeader("X-User-Id") Long userId,
 		@Valid @RequestBody UserUpdateRequestDto request
 	) {
-		UserResponseDto response = userService.updateUser(id, request);
+		UserResponseDto response = userService.updateUser(userId, request);
 		return CommonApiResponse.success(SuccessCode.SUCCESS, response);
 	}
 
@@ -65,12 +65,12 @@ public class UserController {
 		description = "사용자를 삭제합니다."
 	)
 	@ApiExceptions({UserErrorCode.class, ErrorCode.class})
-	@DeleteMapping("/{id}")
+	@DeleteMapping
 	public CommonApiResponse<Void> deleteUser(
-		@Parameter(description = "사용자 ID", required = true, example = "1")
-		@PathVariable Long id
+		@Parameter(description = "사용자 ID (X-User-Id 헤더)", required = true, example = "1")
+		@RequestHeader("X-User-Id") Long userId
 	) {
-		userService.deleteUser(id);
+		userService.deleteUser(userId);
 		return CommonApiResponse.success(SuccessCode.SUCCESS);
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/UserProcedureController.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/UserProcedureController.java
@@ -2,9 +2,9 @@ package com.sopt.cherrish.domain.userprocedure.presentation;
 
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.PathVariable;
 
 import com.sopt.cherrish.domain.procedure.exception.ProcedureErrorCode;
 import com.sopt.cherrish.domain.user.exception.UserErrorCode;
@@ -24,7 +24,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/users/{userId}/procedures")
+@RequestMapping("/api/users/procedures")
 @RequiredArgsConstructor
 @Tag(name = "UserProcedure", description = "사용자 시술 일정 API")
 public class UserProcedureController {
@@ -38,8 +38,8 @@ public class UserProcedureController {
 	@ApiExceptions({UserProcedureErrorCode.class, ProcedureErrorCode.class, UserErrorCode.class, ErrorCode.class})
 	@PostMapping
 	public CommonApiResponse<UserProcedureCreateResponseDto> createUserProcedures(
-		@Parameter(description = "사용자 ID", required = true, example = "1")
-		@PathVariable Long userId,
+		@Parameter(description = "사용자 ID (X-User-Id 헤더)", required = true, example = "1")
+		@RequestHeader("X-User-Id") Long userId,
 		@Valid @RequestBody UserProcedureCreateRequestDto request
 	) {
 		UserProcedureCreateResponseDto response = userProcedureService.createUserProcedures(userId, request);

--- a/src/test/java/com/sopt/cherrish/domain/challenge/core/presentation/ChallengeControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/challenge/core/presentation/ChallengeControllerTest.java
@@ -74,7 +74,7 @@ class ChallengeControllerTest {
 	private ChallengeRoutineService challengeRoutineService;
 
 	@Nested
-	@DisplayName("POST /api/challenges/{userId} - 챌린지 생성")
+	@DisplayName("POST /api/challenges - 챌린지 생성")
 	class CreateChallenge {
 
 		@Test
@@ -88,7 +88,8 @@ class ChallengeControllerTest {
 				.willReturn(response);
 
 			// when & then
-			mockMvc.perform(post("/api/challenges/{userId}", DEFAULT_USER_ID)
+			mockMvc.perform(post("/api/challenges")
+					.header("X-User-Id", DEFAULT_USER_ID)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isOk())
@@ -108,7 +109,8 @@ class ChallengeControllerTest {
 				.willThrow(new UserException(UserErrorCode.USER_NOT_FOUND));
 
 			// when & then
-			mockMvc.perform(post("/api/challenges/{userId}", invalidUserId)
+			mockMvc.perform(post("/api/challenges")
+					.header("X-User-Id", invalidUserId)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isNotFound());
@@ -124,7 +126,8 @@ class ChallengeControllerTest {
 				.willThrow(new ChallengeException(ChallengeErrorCode.DUPLICATE_ACTIVE_CHALLENGE));
 
 			// when & then
-			mockMvc.perform(post("/api/challenges/{userId}", DEFAULT_USER_ID)
+			mockMvc.perform(post("/api/challenges")
+					.header("X-User-Id", DEFAULT_USER_ID)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isConflict());
@@ -137,7 +140,8 @@ class ChallengeControllerTest {
 			ChallengeCreateRequestDto request = createRequestWithEmptyTitle();
 
 			// when & then
-			mockMvc.perform(post("/api/challenges/{userId}", DEFAULT_USER_ID)
+			mockMvc.perform(post("/api/challenges")
+					.header("X-User-Id", DEFAULT_USER_ID)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isBadRequest());
@@ -145,7 +149,7 @@ class ChallengeControllerTest {
 	}
 
 	@Nested
-	@DisplayName("GET /api/challenges/{userId} - 활성 챌린지 조회")
+	@DisplayName("GET /api/challenges - 활성 챌린지 조회")
 	class GetActiveChallenge {
 
 		@Test
@@ -158,7 +162,8 @@ class ChallengeControllerTest {
 				.willReturn(response);
 
 			// when & then
-			mockMvc.perform(get("/api/challenges/{userId}", DEFAULT_USER_ID))
+			mockMvc.perform(get("/api/challenges")
+					.header("X-User-Id", DEFAULT_USER_ID))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.data.challengeId").value(DEFAULT_CHALLENGE_ID))
 				.andExpect(jsonPath("$.data.currentDay").value(3))
@@ -173,7 +178,8 @@ class ChallengeControllerTest {
 				.willThrow(new ChallengeException(ChallengeErrorCode.CHALLENGE_NOT_FOUND));
 
 			// when & then
-			mockMvc.perform(get("/api/challenges/{userId}", DEFAULT_USER_ID))
+			mockMvc.perform(get("/api/challenges")
+					.header("X-User-Id", DEFAULT_USER_ID))
 				.andExpect(status().isNotFound());
 		}
 
@@ -187,13 +193,14 @@ class ChallengeControllerTest {
 				.willThrow(new UserException(UserErrorCode.USER_NOT_FOUND));
 
 			// when & then
-			mockMvc.perform(get("/api/challenges/{userId}", invalidUserId))
+			mockMvc.perform(get("/api/challenges")
+					.header("X-User-Id", invalidUserId))
 				.andExpect(status().isNotFound());
 		}
 	}
 
 	@Nested
-	@DisplayName("PATCH /api/challenges/{userId}/routines/{routineId} - 루틴 완료 토글")
+	@DisplayName("PATCH /api/challenges/routines/{routineId} - 루틴 완료 토글")
 	class ToggleRoutineCompletion {
 
 		@ParameterizedTest
@@ -210,7 +217,8 @@ class ChallengeControllerTest {
 				.willReturn(response);
 
 			// when & then
-			mockMvc.perform(patch("/api/challenges/{userId}/routines/{routineId}", DEFAULT_USER_ID, DEFAULT_ROUTINE_ID))
+			mockMvc.perform(patch("/api/challenges/routines/{routineId}", DEFAULT_ROUTINE_ID)
+					.header("X-User-Id", DEFAULT_USER_ID))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.data.routineId").value(DEFAULT_ROUTINE_ID))
 				.andExpect(jsonPath("$.data.isComplete").value(isComplete));
@@ -226,7 +234,8 @@ class ChallengeControllerTest {
 				.willThrow(new ChallengeException(ChallengeErrorCode.ROUTINE_NOT_FOUND));
 
 			// when & then
-			mockMvc.perform(patch("/api/challenges/{userId}/routines/{routineId}", DEFAULT_USER_ID, invalidRoutineId))
+			mockMvc.perform(patch("/api/challenges/routines/{routineId}", invalidRoutineId)
+					.header("X-User-Id", DEFAULT_USER_ID))
 				.andExpect(status().isNotFound());
 		}
 
@@ -238,7 +247,8 @@ class ChallengeControllerTest {
 				.willThrow(new ChallengeException(ChallengeErrorCode.UNAUTHORIZED_ACCESS));
 
 			// when & then
-			mockMvc.perform(patch("/api/challenges/{userId}/routines/{routineId}", DEFAULT_USER_ID, DEFAULT_ROUTINE_ID))
+			mockMvc.perform(patch("/api/challenges/routines/{routineId}", DEFAULT_ROUTINE_ID)
+					.header("X-User-Id", DEFAULT_USER_ID))
 				.andExpect(status().isForbidden());
 		}
 	}
@@ -254,7 +264,8 @@ class ChallengeControllerTest {
 			ChallengeCreateRequestDto request = createRequestWithNullTitle();
 
 			// when & then
-			mockMvc.perform(post("/api/challenges/{userId}", DEFAULT_USER_ID)
+			mockMvc.perform(post("/api/challenges")
+					.header("X-User-Id", DEFAULT_USER_ID)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isBadRequest());
@@ -267,7 +278,8 @@ class ChallengeControllerTest {
 			ChallengeCreateRequestDto request = createRequestWithEmptyRoutines();
 
 			// when & then
-			mockMvc.perform(post("/api/challenges/{userId}", DEFAULT_USER_ID)
+			mockMvc.perform(post("/api/challenges")
+					.header("X-User-Id", DEFAULT_USER_ID)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isBadRequest());
@@ -280,7 +292,8 @@ class ChallengeControllerTest {
 			ChallengeCreateRequestDto request = createRequestWithTooManyRoutines();
 
 			// when & then
-			mockMvc.perform(post("/api/challenges/{userId}", DEFAULT_USER_ID)
+			mockMvc.perform(post("/api/challenges")
+					.header("X-User-Id", DEFAULT_USER_ID)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isBadRequest());
@@ -288,7 +301,7 @@ class ChallengeControllerTest {
 	}
 
 	@Nested
-	@DisplayName("PATCH /api/challenges/{userId}/routines - 루틴 일괄 업데이트")
+	@DisplayName("PATCH /api/challenges/routines - 루틴 일괄 업데이트")
 	class UpdateMultipleRoutines {
 
 		@Test
@@ -302,7 +315,8 @@ class ChallengeControllerTest {
 				.willReturn(response);
 
 			// when & then
-			mockMvc.perform(patch("/api/challenges/{userId}/routines", DEFAULT_USER_ID)
+			mockMvc.perform(patch("/api/challenges/routines")
+					.header("X-User-Id", DEFAULT_USER_ID)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isOk())
@@ -322,7 +336,8 @@ class ChallengeControllerTest {
 				.willReturn(response);
 
 			// when & then
-			mockMvc.perform(patch("/api/challenges/{userId}/routines", DEFAULT_USER_ID)
+			mockMvc.perform(patch("/api/challenges/routines")
+					.header("X-User-Id", DEFAULT_USER_ID)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isOk())
@@ -338,7 +353,8 @@ class ChallengeControllerTest {
 			RoutineUpdateRequestDto request = createRoutineUpdateRequestWithEmptyList();
 
 			// when & then
-			mockMvc.perform(patch("/api/challenges/{userId}/routines", DEFAULT_USER_ID)
+			mockMvc.perform(patch("/api/challenges/routines")
+					.header("X-User-Id", DEFAULT_USER_ID)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isBadRequest());
@@ -351,7 +367,8 @@ class ChallengeControllerTest {
 			RoutineUpdateRequestDto request = createRoutineUpdateRequestWithNullRoutineId();
 
 			// when & then
-			mockMvc.perform(patch("/api/challenges/{userId}/routines", DEFAULT_USER_ID)
+			mockMvc.perform(patch("/api/challenges/routines")
+					.header("X-User-Id", DEFAULT_USER_ID)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isBadRequest());
@@ -364,7 +381,8 @@ class ChallengeControllerTest {
 			RoutineUpdateRequestDto request = createRoutineUpdateRequestWithNullIsComplete();
 
 			// when & then
-			mockMvc.perform(patch("/api/challenges/{userId}/routines", DEFAULT_USER_ID)
+			mockMvc.perform(patch("/api/challenges/routines")
+					.header("X-User-Id", DEFAULT_USER_ID)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isBadRequest());
@@ -380,7 +398,8 @@ class ChallengeControllerTest {
 				.willThrow(new ChallengeException(ChallengeErrorCode.ROUTINE_NOT_FOUND));
 
 			// when & then
-			mockMvc.perform(patch("/api/challenges/{userId}/routines", DEFAULT_USER_ID)
+			mockMvc.perform(patch("/api/challenges/routines")
+					.header("X-User-Id", DEFAULT_USER_ID)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isNotFound());
@@ -396,7 +415,8 @@ class ChallengeControllerTest {
 				.willThrow(new ChallengeException(ChallengeErrorCode.ROUTINES_FROM_DIFFERENT_CHALLENGES));
 
 			// when & then
-			mockMvc.perform(patch("/api/challenges/{userId}/routines", DEFAULT_USER_ID)
+			mockMvc.perform(patch("/api/challenges/routines")
+					.header("X-User-Id", DEFAULT_USER_ID)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isBadRequest());
@@ -412,7 +432,8 @@ class ChallengeControllerTest {
 				.willThrow(new ChallengeException(ChallengeErrorCode.UNAUTHORIZED_ACCESS));
 
 			// when & then
-			mockMvc.perform(patch("/api/challenges/{userId}/routines", DEFAULT_USER_ID)
+			mockMvc.perform(patch("/api/challenges/routines")
+					.header("X-User-Id", DEFAULT_USER_ID)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isForbidden());

--- a/src/test/java/com/sopt/cherrish/domain/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/user/presentation/UserControllerTest.java
@@ -54,7 +54,8 @@ class UserControllerTest {
 		given(userService.getUser(userId)).willReturn(response);
 
 		// when & then
-		mockMvc.perform(get("/api/users/{id}", userId))
+		mockMvc.perform(get("/api/users")
+				.header("X-User-Id", userId))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.name").value("홍길동"))
 			.andExpect(jsonPath("$.data.age").value(25));
@@ -79,7 +80,8 @@ class UserControllerTest {
 			.willReturn(response);
 
 		// when & then
-		mockMvc.perform(patch("/api/users/{id}", userId)
+		mockMvc.perform(patch("/api/users")
+				.header("X-User-Id", userId)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isOk())
@@ -95,7 +97,8 @@ class UserControllerTest {
 		willDoNothing().given(userService).deleteUser(userId);
 
 		// when & then
-		mockMvc.perform(delete("/api/users/{id}", userId))
+		mockMvc.perform(delete("/api/users")
+				.header("X-User-Id", userId))
 			.andExpect(status().isOk());
 	}
 }

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/presentation/UserProcedureControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/presentation/UserProcedureControllerTest.java
@@ -46,7 +46,7 @@ class UserProcedureControllerTest {
 	private UserProcedureService userProcedureService;
 
 	@Nested
-	@DisplayName("POST /api/users/{userId}/procedures - 사용자 시술 일정 등록")
+	@DisplayName("POST /api/users/procedures - 사용자 시술 일정 등록")
 	class CreateUserProcedures {
 
 		@Test
@@ -61,7 +61,8 @@ class UserProcedureControllerTest {
 				.willReturn(response);
 
 			// when & then
-			mockMvc.perform(post("/api/users/{userId}/procedures", userId)
+			mockMvc.perform(post("/api/users/procedures")
+				.header("X-User-Id", userId)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isOk())
@@ -94,7 +95,8 @@ class UserProcedureControllerTest {
 				.willThrow(new UserException(UserErrorCode.USER_NOT_FOUND));
 
 			// when & then
-			mockMvc.perform(post("/api/users/{userId}/procedures", userId)
+			mockMvc.perform(post("/api/users/procedures")
+				.header("X-User-Id", userId)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isNotFound());
@@ -111,7 +113,8 @@ class UserProcedureControllerTest {
 				.willThrow(new ProcedureException(ProcedureErrorCode.PROCEDURE_NOT_FOUND));
 
 			// when & then
-			mockMvc.perform(post("/api/users/{userId}/procedures", userId)
+			mockMvc.perform(post("/api/users/procedures")
+				.header("X-User-Id", userId)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isNotFound());
@@ -124,7 +127,8 @@ class UserProcedureControllerTest {
 			String invalidRequest = createInvalidRequestWithEmptyProcedures();
 
 			// when & then
-			mockMvc.perform(post("/api/users/{userId}/procedures", 1L)
+			mockMvc.perform(post("/api/users/procedures")
+				.header("X-User-Id", 1L)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(invalidRequest))
 				.andExpect(status().isBadRequest())
@@ -140,7 +144,8 @@ class UserProcedureControllerTest {
 			String invalidRequest = createInvalidRequestWithNegativeDowntime();
 
 			// when & then
-			mockMvc.perform(post("/api/users/{userId}/procedures", 1L)
+			mockMvc.perform(post("/api/users/procedures")
+				.header("X-User-Id", 1L)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(invalidRequest))
 				.andExpect(status().isBadRequest())
@@ -156,7 +161,8 @@ class UserProcedureControllerTest {
 			String invalidRequest = createInvalidRequestMissingScheduledAt();
 
 			// when & then
-			mockMvc.perform(post("/api/users/{userId}/procedures", 1L)
+			mockMvc.perform(post("/api/users/procedures")
+				.header("X-User-Id", 1L)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(invalidRequest))
 				.andExpect(status().isBadRequest())


### PR DESCRIPTION
  # 🛠 Related issue 🛠
  - closed #44 

  # ✏️ Work Description ✏️
  - **API userId 전달 방식 변경: PathVariable → RequestHeader**
      - 모든 Controller에서 userId를 `@PathVariable`에서 `@RequestHeader("X-User-Id")`로 변경
      - Spring Security 도입을 위한 사전 작업

  - **ChallengeController 리팩토링**
      - `POST /api/challenges/{userId}` → `POST /api/challenges` + `X-User-Id` 헤더
      - `GET /api/challenges/{userId}` → `GET /api/challenges` + `X-User-Id` 헤더
      - `PATCH /api/challenges/{userId}/routines/{routineId}` → `PATCH /api/challenges/routines/{routineId}` + 헤더
      - `PATCH /api/challenges/{userId}/routines` → `PATCH /api/challenges/routines` + 헤더
      - TODO 주석 업데이트: "PathVariable userId" → "RequestHeader userId"

  - **UserController 리팩토링**
      - `GET /api/users/{id}` → `GET /api/users` + `X-User-Id` 헤더
      - `PATCH /api/users/{id}` → `PATCH /api/users` + `X-User-Id` 헤더
      - `DELETE /api/users/{id}` → `DELETE /api/users` + `X-User-Id` 헤더
      - PathVariable 제거 및 `@PathVariable` import 제거

  - **UserProcedureController 리팩토링**
      - RequestMapping 경로: `/api/users/{userId}/procedures` → `/api/users/procedures`
      - `POST` 메서드에 `X-User-Id` 헤더 추가
      - PathVariable 제거 및 `@PathVariable` import 제거

  - **테스트 코드 업데이트 (3개 파일)**
      - `ChallengeControllerTest`: 모든 MockMvc 요청에 `.header("X-User-Id", userId)` 추가 (22개 테스트)
      - `UserControllerTest`: 경로에서 `{id}` 제거 및 헤더 추가 (3개 테스트)
      - `UserProcedureControllerTest`: 경로 변경 및 헤더 추가 (6개 테스트)
      - DisplayName 업데이트: 변경된 API 경로 반영

  # 😅 Uncompleted Tasks 😅
  - 없음 (모든 작업 완료)

  # 📢 To Reviewers 📢
  - **주요 변경 사항**
    - userId 전달 방식이 PathVariable → RequestHeader(`X-User-Id`)로 변경되었습니다
    - 이는 향후 Spring Security + JWT 인증 도입 시 `@AuthenticationPrincipal`로 전환하기 위한 중간 단계입니다

  - **리뷰 포인트**
    - Controller의 모든 메서드가 `@RequestHeader("X-User-Id")` 파라미터를 올바르게 받고 있는지 확인
    - API 경로가 일관성 있게 변경되었는지 확인 (특히 `/api/challenges/routines`, `/api/users/procedures`)
    - 테스트 코드가 모두 헤더 방식으로 변경되어 통과하는지 확인
    - Swagger 문서의 `@Parameter` description이 업데이트되었는지 확인

  - **변경 영향 범위**
    - 모든 Controller API의 요청 형식이 변경됨 (Breaking Change)
    - 프론트엔드에서 API 호출 시 `X-User-Id` 헤더를 추가해야 함
    - 기존 PathVariable 방식은 더 이상 작동하지 않음

  - **후속 작업**
    - Spring Security 도입 후 `@RequestHeader("X-User-Id")`를 `@AuthenticationPrincipal`로 교체 예정