### PR TITLE
[Task]커스텀 루틴 개수 제한 로직 추가

### DIFF
--- a/src/main/java/com/sopt/cherrish/domain/challenge/core/application/facade/ChallengeCustomRoutineFacade.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/core/application/facade/ChallengeCustomRoutineFacade.java
@@ -25,6 +25,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ChallengeCustomRoutineFacade {
 
+	static final int MAX_DAILY_ROUTINE_COUNT = 20;
+
 	private final UserService userService;
 	private final ChallengeService challengeService;
 	private final ChallengeRoutineService routineService;
@@ -54,11 +56,11 @@ public class ChallengeCustomRoutineFacade {
 		// 3. 오늘 날짜 계산
 		LocalDate today = LocalDate.now(clock);
 
-		// 4. 하루 최대 루틴 개수 제한 검증 (20개)
+		// 4. 하루 최대 루틴 개수 제한 검증
 		long todayRoutineCount = routineRepository.countByChallengeIdAndScheduledDate(
 			challenge.getId(), today
 		);
-		if (todayRoutineCount >= 20) {
+		if (todayRoutineCount >= MAX_DAILY_ROUTINE_COUNT) {
 			throw new ChallengeException(ChallengeErrorCode.CUSTOM_ROUTINE_LIMIT_EXCEEDED);
 		}
 

--- a/src/main/java/com/sopt/cherrish/domain/challenge/core/application/facade/ChallengeCustomRoutineFacade.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/core/application/facade/ChallengeCustomRoutineFacade.java
@@ -12,6 +12,9 @@ import com.sopt.cherrish.domain.challenge.core.application.service.ChallengeServ
 import com.sopt.cherrish.domain.challenge.core.domain.model.Challenge;
 import com.sopt.cherrish.domain.challenge.core.domain.model.ChallengeRoutine;
 import com.sopt.cherrish.domain.challenge.core.domain.model.ChallengeStatistics;
+import com.sopt.cherrish.domain.challenge.core.domain.repository.ChallengeRoutineRepository;
+import com.sopt.cherrish.domain.challenge.core.exception.ChallengeErrorCode;
+import com.sopt.cherrish.domain.challenge.core.exception.ChallengeException;
 import com.sopt.cherrish.domain.challenge.core.presentation.dto.request.CustomRoutineAddRequestDto;
 import com.sopt.cherrish.domain.challenge.core.presentation.dto.response.CustomRoutineAddResponseDto;
 import com.sopt.cherrish.domain.user.application.service.UserService;
@@ -25,6 +28,7 @@ public class ChallengeCustomRoutineFacade {
 	private final UserService userService;
 	private final ChallengeService challengeService;
 	private final ChallengeRoutineService routineService;
+	private final ChallengeRoutineRepository routineRepository;
 	private final Clock clock;
 
 	/**
@@ -50,17 +54,25 @@ public class ChallengeCustomRoutineFacade {
 		// 3. 오늘 날짜 계산
 		LocalDate today = LocalDate.now(clock);
 
-		// 4. 커스텀 루틴 Batch Insert
+		// 4. 하루 최대 루틴 개수 제한 검증 (20개)
+		long todayRoutineCount = routineRepository.countByChallengeIdAndScheduledDate(
+			challenge.getId(), today
+		);
+		if (todayRoutineCount >= 20) {
+			throw new ChallengeException(ChallengeErrorCode.CUSTOM_ROUTINE_LIMIT_EXCEEDED);
+		}
+
+		// 5. 커스텀 루틴 Batch Insert
 		List<ChallengeRoutine> routines = routineService.createAndSaveCustomRoutine(
 			challenge, request.routineName(), today
 		);
 
-		// 5. 통계 업데이트 (totalRoutineCount 증가, cherryLevel 재계산)
+		// 6. 통계 업데이트 (totalRoutineCount 증가, cherryLevel 재계산)
 		ChallengeStatistics statistics = challenge.getStatistics();
 		statistics.incrementTotalRoutineCount(routines.size());
 		statistics.updateCherryLevel();
 
-		// 6. Response DTO 변환
+		// 7. Response DTO 변환
 		return CustomRoutineAddResponseDto.from(
 			challenge,
 			request.routineName(),

--- a/src/main/java/com/sopt/cherrish/domain/challenge/core/domain/repository/ChallengeRoutineRepository.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/core/domain/repository/ChallengeRoutineRepository.java
@@ -28,6 +28,15 @@ public interface ChallengeRoutineRepository extends JpaRepository<ChallengeRouti
 	List<ChallengeRoutine> findByChallengeIdAndScheduledDate(Long challengeId, LocalDate scheduledDate);
 
 	/**
+	 * 챌린지의 특정 날짜 루틴 개수 조회
+	 * 커스텀 루틴 추가 시 하루 최대 20개 제한 검증에 사용
+	 * @param challengeId 챌린지 ID
+	 * @param scheduledDate 예정일
+	 * @return 루틴 개수
+	 */
+	long countByChallengeIdAndScheduledDate(Long challengeId, LocalDate scheduledDate);
+
+	/**
 	 * 루틴 조회 (Challenge와 함께 fetch)
 	 * @param id 루틴 ID
 	 * @return 루틴 (Challenge 포함)

--- a/src/main/java/com/sopt/cherrish/domain/challenge/core/exception/ChallengeErrorCode.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/core/exception/ChallengeErrorCode.java
@@ -18,7 +18,8 @@ public enum ChallengeErrorCode implements ErrorType {
 	ROUTINE_OUT_OF_CHALLENGE_PERIOD("CH007", "챌린지 기간 외의 루틴은 수정할 수 없습니다", 400),
 	ROUTINES_FROM_DIFFERENT_CHALLENGES("CH008", "서로 다른 챌린지의 루틴은 함께 업데이트할 수 없습니다", 400),
 	DUPLICATE_ROUTINE_IDS("CH009", "중복된 루틴 ID가 포함되어 있습니다", 400),
-	CHALLENGE_NOT_ACTIVE("CH010", "비활성 챌린지에는 루틴을 추가할 수 없습니다", 400);
+	CHALLENGE_NOT_ACTIVE("CH010", "비활성 챌린지에는 루틴을 추가할 수 없습니다", 400),
+	CUSTOM_ROUTINE_LIMIT_EXCEEDED("CH011", "하루에 추가할 수 있는 루틴은 최대 20개입니다", 400);
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/sopt/cherrish/domain/challenge/core/exception/ChallengeErrorCode.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/core/exception/ChallengeErrorCode.java
@@ -19,7 +19,7 @@ public enum ChallengeErrorCode implements ErrorType {
 	ROUTINES_FROM_DIFFERENT_CHALLENGES("CH008", "서로 다른 챌린지의 루틴은 함께 업데이트할 수 없습니다", 400),
 	DUPLICATE_ROUTINE_IDS("CH009", "중복된 루틴 ID가 포함되어 있습니다", 400),
 	CHALLENGE_NOT_ACTIVE("CH010", "비활성 챌린지에는 루틴을 추가할 수 없습니다", 400),
-	CUSTOM_ROUTINE_LIMIT_EXCEEDED("CH011", "하루에 추가할 수 있는 루틴은 최대 20개입니다", 400);
+	CUSTOM_ROUTINE_LIMIT_EXCEEDED("CH011", "최대로 추가할 수 있는 루틴은 20개입니다", 400);
 
 	private final String code;
 	private final String message;

--- a/src/test/java/com/sopt/cherrish/domain/challenge/core/application/facade/ChallengeCustomRoutineFacadeIntegrationTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/challenge/core/application/facade/ChallengeCustomRoutineFacadeIntegrationTest.java
@@ -282,14 +282,15 @@ class ChallengeCustomRoutineFacadeIntegrationTest {
 	}
 
 	@Test
-	@DisplayName("성공 - 오늘 날짜에 19개 루틴 → 커스텀 1개 추가 가능 (20개 제한)")
+	@DisplayName("성공 - 오늘 날짜에 19개 루틴 → 커스텀 1개 추가 가능 (제한-1)")
 	void addCustomRoutineSuccessWhen19RoutinesExist() {
 		// given
 		User user = createTestUser();
 		Challenge challenge = createActiveChallengeWithRoutines(user, 3);
 
-		// 오늘(2024-01-01)에 추가로 16개 루틴 생성 (기존 3개 + 16개 = 19개)
-		for (int i = 0; i < 16; i++) {
+		// 오늘(2024-01-01)에 추가로 루틴 생성 (기존 3개 + 추가 = MAX-1개)
+		int additionalRoutines = ChallengeCustomRoutineFacade.MAX_DAILY_ROUTINE_COUNT - 3 - 1;
+		for (int i = 0; i < additionalRoutines; i++) {
 			routineRepository.save(ChallengeRoutine.builder()
 				.challenge(challenge)
 				.name("추가 루틴 " + (i + 1))
@@ -300,22 +301,22 @@ class ChallengeCustomRoutineFacadeIntegrationTest {
 		// 통계 업데이트
 		ChallengeStatistics statistics = statisticsRepository.findByChallengeId(challenge.getId())
 			.orElseThrow();
-		statistics.incrementTotalRoutineCount(16);
+		statistics.incrementTotalRoutineCount(additionalRoutines);
 		statisticsRepository.save(statistics);
 
 		entityManager.flush();
 		entityManager.clear();
 
-		CustomRoutineAddRequestDto request = new CustomRoutineAddRequestDto("20번째 루틴");
+		CustomRoutineAddRequestDto request = new CustomRoutineAddRequestDto("마지막 루틴");
 
-		// when - 오늘 19개 → 20번째 추가 (성공)
+		// when - 오늘 MAX-1개 → MAX번째 추가 (성공)
 		CustomRoutineAddResponseDto response = challengeCustomRoutineFacade.addCustomRoutine(
 			user.getId(),
 			request
 		);
 
 		// then
-		assertThat(response.routineName()).isEqualTo("20번째 루틴");
+		assertThat(response.routineName()).isEqualTo("마지막 루틴");
 		assertThat(response.addedCount()).isEqualTo(7);
 
 		// 오늘 날짜의 루틴 개수 확인
@@ -323,18 +324,19 @@ class ChallengeCustomRoutineFacadeIntegrationTest {
 			challenge.getId(),
 			FIXED_START_DATE
 		);
-		assertThat(todayRoutineCount).isEqualTo(20); // 19 + 1 = 20
+		assertThat(todayRoutineCount).isEqualTo(ChallengeCustomRoutineFacade.MAX_DAILY_ROUTINE_COUNT);
 	}
 
 	@Test
-	@DisplayName("실패 - 오늘 날짜에 20개 루틴 → 커스텀 추가 불가 (20개 제한 초과)")
+	@DisplayName("실패 - 오늘 날짜에 MAX개 루틴 → 커스텀 추가 불가 (제한 초과)")
 	void addCustomRoutineFailsWhen20RoutinesExist() {
 		// given
 		User user = createTestUser();
 		Challenge challenge = createActiveChallengeWithRoutines(user, 3);
 
-		// 오늘(2024-01-01)에 추가로 17개 루틴 생성 (기존 3개 + 17개 = 20개)
-		for (int i = 0; i < 17; i++) {
+		// 오늘(2024-01-01)에 추가로 루틴 생성 (기존 3개 + 추가 = MAX개)
+		int additionalRoutines = ChallengeCustomRoutineFacade.MAX_DAILY_ROUTINE_COUNT - 3;
+		for (int i = 0; i < additionalRoutines; i++) {
 			routineRepository.save(ChallengeRoutine.builder()
 				.challenge(challenge)
 				.name("추가 루틴 " + (i + 1))
@@ -345,15 +347,15 @@ class ChallengeCustomRoutineFacadeIntegrationTest {
 		// 통계 업데이트
 		ChallengeStatistics statistics = statisticsRepository.findByChallengeId(challenge.getId())
 			.orElseThrow();
-		statistics.incrementTotalRoutineCount(17);
+		statistics.incrementTotalRoutineCount(additionalRoutines);
 		statisticsRepository.save(statistics);
 
 		entityManager.flush();
 		entityManager.clear();
 
-		CustomRoutineAddRequestDto request = new CustomRoutineAddRequestDto("21번째 루틴");
+		CustomRoutineAddRequestDto request = new CustomRoutineAddRequestDto("초과 루틴");
 
-		// when & then - 오늘 20개 → 21번째 추가 시도 (실패)
+		// when & then - 오늘 MAX개 → MAX+1번째 추가 시도 (실패)
 		assertThatThrownBy(() -> challengeCustomRoutineFacade.addCustomRoutine(user.getId(), request))
 			.isInstanceOf(ChallengeException.class)
 			.hasFieldOrPropertyWithValue("errorCode", ChallengeErrorCode.CUSTOM_ROUTINE_LIMIT_EXCEEDED);
@@ -363,7 +365,7 @@ class ChallengeCustomRoutineFacadeIntegrationTest {
 			challenge.getId(),
 			FIXED_START_DATE
 		);
-		assertThat(todayRoutineCount).isEqualTo(20); // 여전히 20개
+		assertThat(todayRoutineCount).isEqualTo(ChallengeCustomRoutineFacade.MAX_DAILY_ROUTINE_COUNT);
 	}
 
 	@Test

--- a/src/test/java/com/sopt/cherrish/domain/challenge/core/application/facade/ChallengeCustomRoutineFacadeIntegrationTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/challenge/core/application/facade/ChallengeCustomRoutineFacadeIntegrationTest.java
@@ -280,4 +280,116 @@ class ChallengeCustomRoutineFacadeIntegrationTest {
 			.orElseThrow();
 		assertThat(statistics.getTotalRoutineCount()).isEqualTo(initialTotalRoutineCount);
 	}
+
+	@Test
+	@DisplayName("성공 - 오늘 날짜에 19개 루틴 → 커스텀 1개 추가 가능 (20개 제한)")
+	void addCustomRoutineSuccessWhen19RoutinesExist() {
+		// given
+		User user = createTestUser();
+		Challenge challenge = createActiveChallengeWithRoutines(user, 3);
+
+		// 오늘(2024-01-01)에 추가로 16개 루틴 생성 (기존 3개 + 16개 = 19개)
+		for (int i = 0; i < 16; i++) {
+			routineRepository.save(ChallengeRoutine.builder()
+				.challenge(challenge)
+				.name("추가 루틴 " + (i + 1))
+				.scheduledDate(FIXED_START_DATE) // 오늘
+				.build());
+		}
+
+		// 통계 업데이트
+		ChallengeStatistics statistics = statisticsRepository.findByChallengeId(challenge.getId())
+			.orElseThrow();
+		statistics.incrementTotalRoutineCount(16);
+		statisticsRepository.save(statistics);
+
+		entityManager.flush();
+		entityManager.clear();
+
+		CustomRoutineAddRequestDto request = new CustomRoutineAddRequestDto("20번째 루틴");
+
+		// when - 오늘 19개 → 20번째 추가 (성공)
+		CustomRoutineAddResponseDto response = challengeCustomRoutineFacade.addCustomRoutine(
+			user.getId(),
+			request
+		);
+
+		// then
+		assertThat(response.routineName()).isEqualTo("20번째 루틴");
+		assertThat(response.addedCount()).isEqualTo(7);
+
+		// 오늘 날짜의 루틴 개수 확인
+		long todayRoutineCount = routineRepository.countByChallengeIdAndScheduledDate(
+			challenge.getId(),
+			FIXED_START_DATE
+		);
+		assertThat(todayRoutineCount).isEqualTo(20); // 19 + 1 = 20
+	}
+
+	@Test
+	@DisplayName("실패 - 오늘 날짜에 20개 루틴 → 커스텀 추가 불가 (20개 제한 초과)")
+	void addCustomRoutineFailsWhen20RoutinesExist() {
+		// given
+		User user = createTestUser();
+		Challenge challenge = createActiveChallengeWithRoutines(user, 3);
+
+		// 오늘(2024-01-01)에 추가로 17개 루틴 생성 (기존 3개 + 17개 = 20개)
+		for (int i = 0; i < 17; i++) {
+			routineRepository.save(ChallengeRoutine.builder()
+				.challenge(challenge)
+				.name("추가 루틴 " + (i + 1))
+				.scheduledDate(FIXED_START_DATE) // 오늘
+				.build());
+		}
+
+		// 통계 업데이트
+		ChallengeStatistics statistics = statisticsRepository.findByChallengeId(challenge.getId())
+			.orElseThrow();
+		statistics.incrementTotalRoutineCount(17);
+		statisticsRepository.save(statistics);
+
+		entityManager.flush();
+		entityManager.clear();
+
+		CustomRoutineAddRequestDto request = new CustomRoutineAddRequestDto("21번째 루틴");
+
+		// when & then - 오늘 20개 → 21번째 추가 시도 (실패)
+		assertThatThrownBy(() -> challengeCustomRoutineFacade.addCustomRoutine(user.getId(), request))
+			.isInstanceOf(ChallengeException.class)
+			.hasFieldOrPropertyWithValue("errorCode", ChallengeErrorCode.CUSTOM_ROUTINE_LIMIT_EXCEEDED);
+
+		// 루틴이 추가되지 않음
+		long todayRoutineCount = routineRepository.countByChallengeIdAndScheduledDate(
+			challenge.getId(),
+			FIXED_START_DATE
+		);
+		assertThat(todayRoutineCount).isEqualTo(20); // 여전히 20개
+	}
+
+	@Test
+	@DisplayName("성공 - 오늘 날짜에 3개 루틴 (기본) → 커스텀 추가 가능")
+	void addCustomRoutineSuccessWithDefaultRoutines() {
+		// given
+		User user = createTestUser();
+		Challenge challenge = createActiveChallengeWithRoutines(user, 3);
+
+		CustomRoutineAddRequestDto request = new CustomRoutineAddRequestDto("커스텀 루틴");
+
+		// when - 오늘 3개 → 커스텀 추가 (성공)
+		CustomRoutineAddResponseDto response = challengeCustomRoutineFacade.addCustomRoutine(
+			user.getId(),
+			request
+		);
+
+		// then
+		assertThat(response.routineName()).isEqualTo("커스텀 루틴");
+		assertThat(response.addedCount()).isEqualTo(7);
+
+		// 오늘 날짜의 루틴 개수 확인
+		long todayRoutineCount = routineRepository.countByChallengeIdAndScheduledDate(
+			challenge.getId(),
+			FIXED_START_DATE
+		);
+		assertThat(todayRoutineCount).isEqualTo(4); // 3 + 1 = 4
+	}
 }

--- a/src/test/java/com/sopt/cherrish/domain/challenge/core/presentation/ChallengeRoutineControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/challenge/core/presentation/ChallengeRoutineControllerTest.java
@@ -373,10 +373,10 @@ class ChallengeRoutineControllerTest {
 		}
 
 		@Test
-		@DisplayName("실패 - 하루 루틴 20개 제한 초과")
+		@DisplayName("실패 - 하루 루틴 개수 제한 초과")
 		void failCustomRoutineLimitExceeded() throws Exception {
 			// given
-			CustomRoutineAddRequestDto request = new CustomRoutineAddRequestDto("21번째 루틴");
+			CustomRoutineAddRequestDto request = new CustomRoutineAddRequestDto("초과 루틴");
 
 			given(challengeCustomRoutineFacade.addCustomRoutine(eq(DEFAULT_USER_ID), any(CustomRoutineAddRequestDto.class)))
 				.willThrow(new ChallengeException(ChallengeErrorCode.CUSTOM_ROUTINE_LIMIT_EXCEEDED));

--- a/src/test/java/com/sopt/cherrish/domain/challenge/core/presentation/ChallengeRoutineControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/challenge/core/presentation/ChallengeRoutineControllerTest.java
@@ -371,5 +371,23 @@ class ChallengeRoutineControllerTest {
 					.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isBadRequest());
 		}
+
+		@Test
+		@DisplayName("실패 - 하루 루틴 20개 제한 초과")
+		void failCustomRoutineLimitExceeded() throws Exception {
+			// given
+			CustomRoutineAddRequestDto request = new CustomRoutineAddRequestDto("21번째 루틴");
+
+			given(challengeCustomRoutineFacade.addCustomRoutine(eq(DEFAULT_USER_ID), any(CustomRoutineAddRequestDto.class)))
+				.willThrow(new ChallengeException(ChallengeErrorCode.CUSTOM_ROUTINE_LIMIT_EXCEEDED));
+
+			// when & then
+			mockMvc.perform(post("/api/challenges/routines")
+					.header("X-User-Id", DEFAULT_USER_ID)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("CH011"));
+		}
 	}
 }


### PR DESCRIPTION
 # 🛠 Related issue 🛠
 - closed #51

 # ✏️ Work Description ✏️
 - **커스텀 루틴 개수 제한 로직 추가**
     - 하루에 추가할 수 있는 루틴을 최대 20개로 제한
     - 오늘 날짜 기준으로 검증 (커스텀 루틴은 오늘부터 챌린지 종료일까지 추가되므로)
     - 이름 중복 여부와 무관하게 개수만 제한

 - **에러 코드 추가 (ChallengeErrorCode)**
     - `CUSTOM_ROUTINE_LIMIT_EXCEEDED("CH011", "하루에 추가할 수 있는 루틴은 최대 20개입니다", 400)` 추가

 - **Repository 계층 (ChallengeRoutineRepository)**
     - `countByChallengeIdAndScheduledDate(Long challengeId, LocalDate scheduledDate)` 메서드 추가
     - 특정 날짜의 루틴 개수를 카운트하는 쿼리 메서드

 - **Facade 계층 검증 로직 (ChallengeCustomRoutineFacade)**
     - `MAX_DAILY_ROUTINE_COUNT` 상수 추가 (값: 20)
     - 커스텀 루틴 추가 전 오늘 날짜의 루틴 개수 검증
     - 20개 이상일 경우 `CUSTOM_ROUTINE_LIMIT_EXCEEDED` 예외 발생
     - 상수를 package-private(`static final`)으로 선언하여 테스트에서 참조 가능

 - **통합 테스트 작성 (ChallengeCustomRoutineFacadeIntegrationTest)**
     - 19개 → 20번째 추가 성공 케이스
     - 20개 → 21번째 추가 실패 케이스 (예외 발생)
     - 3개 기본 루틴 → 커스텀 추가 성공 케이스
     - 모든 테스트에서 `MAX_DAILY_ROUTINE_COUNT` 상수 참조

 - **컨트롤러 테스트 작성 (ChallengeRoutineControllerTest)**
     - 하루 루틴 개수 제한 초과 시 400 Bad Request 응답 검증
     - CH011 에러 코드 응답 검증

 - **유연한 설정 관리**
     - 하드코딩된 20을 `MAX_DAILY_ROUTINE_COUNT` 상수로 추출
     - 테스트 코드에서 프로덕션 코드의 상수를 참조하여 중복 제거
     - 제한 숫자 변경 시 한 곳만 수정하면 모든 로직과 테스트에 반영

 # 📸 Screenshot 📸
 |              설명               |     사진      |
 |:-----------------------------:|:-----------:|
 | API 테스트는 단위 테스트로 대체 | - |

 # 😅 Uncompleted Tasks 😅
 - 없음

 # 📢 To Reviewers 📢
- 커스텀 루틴을 추가할 때 동시성 문제(19개일 때 2명이 동시에 루틴 추가 요청시 21개가 되는 문제)는 실제로 일어날 확률이 희박하다 생각해 적용하지 않았습니다.
1. 각 유저에게 독립적
2. 커스텀 루틴 추가시 루틴을 직접 입력하고 저장하는 흐름이 존재
