### PR TITLE
[Feature] 캘린더 조회 구현

### DIFF
--- a/src/main/java/com/sopt/cherrish/domain/calendar/application/service/CalendarService.java
+++ b/src/main/java/com/sopt/cherrish/domain/calendar/application/service/CalendarService.java
@@ -1,0 +1,73 @@
+package com.sopt.cherrish.domain.calendar.application.service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sopt.cherrish.domain.calendar.presentation.dto.response.CalendarDailyResponseDto;
+import com.sopt.cherrish.domain.calendar.presentation.dto.response.CalendarMonthlyResponseDto;
+import com.sopt.cherrish.domain.calendar.presentation.dto.response.ProcedureEventResponseDto;
+import com.sopt.cherrish.domain.user.domain.repository.UserRepository;
+import com.sopt.cherrish.domain.user.exception.UserErrorCode;
+import com.sopt.cherrish.domain.user.exception.UserException;
+import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
+import com.sopt.cherrish.domain.userprocedure.domain.repository.UserProcedureRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CalendarService {
+
+	private final UserProcedureRepository userProcedureRepository;
+	private final UserRepository userRepository;
+
+	/**
+	 * 월별 캘린더 조회
+	 * @param userId 사용자 ID
+	 * @param year 연도
+	 * @param month 월
+	 * @return 일자별 시술 개수
+	 */
+	public CalendarMonthlyResponseDto getMonthlyCalendar(Long userId, int year, int month) {
+		// 사용자 존재 여부 확인
+		validateUserExists(userId);
+
+		// 월별 시술 개수 조회
+		Map<Integer, Long> dailyProcedureCounts = userProcedureRepository.findMonthlyProcedureCounts(userId, year,
+			month);
+
+		return CalendarMonthlyResponseDto.from(dailyProcedureCounts);
+	}
+
+	/**
+	 * 일자별 시술 상세 조회
+	 * @param userId 사용자 ID
+	 * @param date 날짜
+	 * @return 시술 이벤트 목록
+	 */
+	public CalendarDailyResponseDto getDailyCalendar(Long userId, LocalDate date) {
+		// 사용자 존재 여부 확인
+		validateUserExists(userId);
+
+		// 특정 날짜의 시술 목록 조회
+		List<UserProcedure> userProcedures = userProcedureRepository.findDailyProcedures(userId, date);
+
+		// UserProcedure -> ProcedureEventDto 변환
+		List<ProcedureEventResponseDto> events = userProcedures.stream()
+			.map(ProcedureEventResponseDto::from)
+			.toList();
+
+		return CalendarDailyResponseDto.from(events);
+	}
+
+	private void validateUserExists(Long userId) {
+		if (!userRepository.existsById(userId)) {
+			throw new UserException(UserErrorCode.USER_NOT_FOUND);
+		}
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/calendar/domain/model/CalendarEventType.java
+++ b/src/main/java/com/sopt/cherrish/domain/calendar/domain/model/CalendarEventType.java
@@ -1,0 +1,5 @@
+package com.sopt.cherrish.domain.calendar.domain.model;
+
+public enum CalendarEventType {
+	PROCEDURE
+}

--- a/src/main/java/com/sopt/cherrish/domain/calendar/presentation/CalendarController.java
+++ b/src/main/java/com/sopt/cherrish/domain/calendar/presentation/CalendarController.java
@@ -44,7 +44,7 @@ public class CalendarController {
 	public CommonApiResponse<CalendarMonthlyResponseDto> getMonthlyCalendar(
 		@Parameter(description = "사용자 ID (X-User-Id 헤더)", required = true, example = "1")
 		@RequestHeader("X-User-Id") Long userId,
-		@Parameter(description = "연도", required = true, example = "2025")
+		@Parameter(description = "연도", required = true, example = "2026")
 		@RequestParam @Min(2000) @Max(2100) int year,
 		@Parameter(description = "월", required = true, example = "1")
 		@RequestParam @Min(1) @Max(12) int month
@@ -62,7 +62,7 @@ public class CalendarController {
 	public CommonApiResponse<CalendarDailyResponseDto> getDailyCalendar(
 		@Parameter(description = "사용자 ID (X-User-Id 헤더)", required = true, example = "1")
 		@RequestHeader("X-User-Id") Long userId,
-		@Parameter(description = "날짜", required = true, example = "2025-01-15")
+		@Parameter(description = "날짜", required = true, example = "2026-01-15")
 		@RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date
 	) {
 		CalendarDailyResponseDto response = calendarService.getDailyCalendar(userId, date);

--- a/src/main/java/com/sopt/cherrish/domain/calendar/presentation/CalendarController.java
+++ b/src/main/java/com/sopt/cherrish/domain/calendar/presentation/CalendarController.java
@@ -1,16 +1,15 @@
 package com.sopt.cherrish.domain.calendar.presentation;
 
-import java.time.LocalDate;
-
-import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.validation.annotation.Validated;
 
 import com.sopt.cherrish.domain.calendar.application.service.CalendarService;
+import com.sopt.cherrish.domain.calendar.presentation.dto.request.CalendarDailyRequestDto;
+import com.sopt.cherrish.domain.calendar.presentation.dto.request.CalendarMonthlyRequestDto;
 import com.sopt.cherrish.domain.calendar.presentation.dto.response.CalendarDailyResponseDto;
 import com.sopt.cherrish.domain.calendar.presentation.dto.response.CalendarMonthlyResponseDto;
 import com.sopt.cherrish.domain.user.exception.UserErrorCode;
@@ -22,8 +21,7 @@ import com.sopt.cherrish.global.response.success.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -44,12 +42,13 @@ public class CalendarController {
 	public CommonApiResponse<CalendarMonthlyResponseDto> getMonthlyCalendar(
 		@Parameter(description = "사용자 ID (X-User-Id 헤더)", required = true, example = "1")
 		@RequestHeader("X-User-Id") Long userId,
-		@Parameter(description = "연도", required = true, example = "2026")
-		@RequestParam @Min(2000) @Max(2100) int year,
-		@Parameter(description = "월", required = true, example = "1")
-		@RequestParam @Min(1) @Max(12) int month
+		@Valid @ModelAttribute CalendarMonthlyRequestDto request
 	) {
-		CalendarMonthlyResponseDto response = calendarService.getMonthlyCalendar(userId, year, month);
+		CalendarMonthlyResponseDto response = calendarService.getMonthlyCalendar(
+			userId,
+			request.year(),
+			request.month()
+		);
 		return CommonApiResponse.success(SuccessCode.SUCCESS, response);
 	}
 
@@ -62,10 +61,9 @@ public class CalendarController {
 	public CommonApiResponse<CalendarDailyResponseDto> getDailyCalendar(
 		@Parameter(description = "사용자 ID (X-User-Id 헤더)", required = true, example = "1")
 		@RequestHeader("X-User-Id") Long userId,
-		@Parameter(description = "날짜", required = true, example = "2026-01-15")
-		@RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date
+		@Valid @ModelAttribute CalendarDailyRequestDto request
 	) {
-		CalendarDailyResponseDto response = calendarService.getDailyCalendar(userId, date);
+		CalendarDailyResponseDto response = calendarService.getDailyCalendar(userId, request.date());
 		return CommonApiResponse.success(SuccessCode.SUCCESS, response);
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/calendar/presentation/CalendarController.java
+++ b/src/main/java/com/sopt/cherrish/domain/calendar/presentation/CalendarController.java
@@ -1,0 +1,71 @@
+package com.sopt.cherrish.domain.calendar.presentation;
+
+import java.time.LocalDate;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.annotation.Validated;
+
+import com.sopt.cherrish.domain.calendar.application.service.CalendarService;
+import com.sopt.cherrish.domain.calendar.presentation.dto.response.CalendarDailyResponseDto;
+import com.sopt.cherrish.domain.calendar.presentation.dto.response.CalendarMonthlyResponseDto;
+import com.sopt.cherrish.domain.user.exception.UserErrorCode;
+import com.sopt.cherrish.global.annotation.ApiExceptions;
+import com.sopt.cherrish.global.response.CommonApiResponse;
+import com.sopt.cherrish.global.response.error.ErrorCode;
+import com.sopt.cherrish.global.response.success.SuccessCode;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/calendar")
+@RequiredArgsConstructor
+@Validated
+@Tag(name = "Calendar", description = "캘린더 조회 API")
+public class CalendarController {
+
+	private final CalendarService calendarService;
+
+	@Operation(
+		summary = "월별 캘린더 조회",
+		description = "특정 연월의 일자별 시술 개수를 조회합니다."
+	)
+	@ApiExceptions({UserErrorCode.class, ErrorCode.class})
+	@GetMapping("/monthly")
+	public CommonApiResponse<CalendarMonthlyResponseDto> getMonthlyCalendar(
+		@Parameter(description = "사용자 ID (X-User-Id 헤더)", required = true, example = "1")
+		@RequestHeader("X-User-Id") Long userId,
+		@Parameter(description = "연도", required = true, example = "2025")
+		@RequestParam @Min(2000) @Max(2100) int year,
+		@Parameter(description = "월", required = true, example = "1")
+		@RequestParam @Min(1) @Max(12) int month
+	) {
+		CalendarMonthlyResponseDto response = calendarService.getMonthlyCalendar(userId, year, month);
+		return CommonApiResponse.success(SuccessCode.SUCCESS, response);
+	}
+
+	@Operation(
+		summary = "일자별 시술 상세 조회",
+		description = "특정 날짜의 시술 목록과 다운타임 기간(민감기/주의기/회복기)을 조회합니다."
+	)
+	@ApiExceptions({UserErrorCode.class, ErrorCode.class})
+	@GetMapping("/daily")
+	public CommonApiResponse<CalendarDailyResponseDto> getDailyCalendar(
+		@Parameter(description = "사용자 ID (X-User-Id 헤더)", required = true, example = "1")
+		@RequestHeader("X-User-Id") Long userId,
+		@Parameter(description = "날짜", required = true, example = "2025-01-15")
+		@RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date
+	) {
+		CalendarDailyResponseDto response = calendarService.getDailyCalendar(userId, date);
+		return CommonApiResponse.success(SuccessCode.SUCCESS, response);
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/calendar/presentation/dto/request/CalendarDailyRequestDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/calendar/presentation/dto/request/CalendarDailyRequestDto.java
@@ -1,0 +1,18 @@
+package com.sopt.cherrish.domain.calendar.presentation.dto.request;
+
+import java.time.LocalDate;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "일자별 시술 상세 조회 요청")
+public record CalendarDailyRequestDto(
+
+	@Schema(description = "날짜", example = "2026-01-15", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotNull(message = "날짜는 필수입니다")
+	@DateTimeFormat(pattern = "yyyy-MM-dd")
+	LocalDate date
+) {
+}

--- a/src/main/java/com/sopt/cherrish/domain/calendar/presentation/dto/request/CalendarMonthlyRequestDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/calendar/presentation/dto/request/CalendarMonthlyRequestDto.java
@@ -1,0 +1,22 @@
+package com.sopt.cherrish.domain.calendar.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "월별 캘린더 조회 요청")
+public record CalendarMonthlyRequestDto(
+	@Schema(description = "연도", example = "2026", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotNull(message = "연도는 필수입니다")
+	@Min(value = 2000, message = "연도는 2000년 이상이어야 합니다")
+	@Max(value = 2100, message = "연도는 2100년 이하여야 합니다")
+	Integer year,
+
+	@Schema(description = "월", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotNull(message = "월은 필수입니다")
+	@Min(value = 1, message = "월은 1 이상이어야 합니다")
+	@Max(value = 12, message = "월은 12 이하여야 합니다")
+	Integer month
+) {
+}

--- a/src/main/java/com/sopt/cherrish/domain/calendar/presentation/dto/response/CalendarDailyResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/calendar/presentation/dto/response/CalendarDailyResponseDto.java
@@ -1,0 +1,26 @@
+package com.sopt.cherrish.domain.calendar.presentation.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "일자별 시술 상세 조회 응답")
+public class CalendarDailyResponseDto {
+
+	@Schema(description = "이벤트 개수", example = "3")
+	private int eventCount;
+
+	@Schema(description = "해당 일자의 시술 이벤트 목록")
+	private List<ProcedureEventResponseDto> events;
+
+	public static CalendarDailyResponseDto from(List<ProcedureEventResponseDto> events) {
+		return CalendarDailyResponseDto.builder()
+			.eventCount(events.size())
+			.events(events)
+			.build();
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/calendar/presentation/dto/response/CalendarMonthlyResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/calendar/presentation/dto/response/CalendarMonthlyResponseDto.java
@@ -1,0 +1,22 @@
+package com.sopt.cherrish.domain.calendar.presentation.dto.response;
+
+import java.util.Map;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "월별 캘린더 응답")
+public class CalendarMonthlyResponseDto {
+
+	@Schema(description = "일자별 시술 개수 (key: 일자, value: 시술 개수)", example = "{\"1\": 2, \"5\": 1, \"10\": 3}")
+	private Map<Integer, Long> dailyProcedureCounts;
+
+	public static CalendarMonthlyResponseDto from(Map<Integer, Long> dailyProcedureCounts) {
+		return CalendarMonthlyResponseDto.builder()
+			.dailyProcedureCounts(dailyProcedureCounts)
+			.build();
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/calendar/presentation/dto/response/ProcedureEventResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/calendar/presentation/dto/response/ProcedureEventResponseDto.java
@@ -1,0 +1,106 @@
+package com.sopt.cherrish.domain.calendar.presentation.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.sopt.cherrish.domain.calendar.domain.model.CalendarEventType;
+import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "캘린더 시술 이벤트")
+public class ProcedureEventResponseDto {
+
+	@Schema(description = "이벤트 타입", example = "PROCEDURE")
+	private CalendarEventType type;
+
+	@Schema(description = "사용자 시술 일정 ID", example = "123")
+	private Long id;
+
+	@Schema(description = "시술 ID", example = "5")
+	private Long procedureId;
+
+	@Schema(description = "시술명", example = "레이저 토닝")
+	private String name;
+
+	@Schema(description = "예약 날짜 및 시간", example = "2025-01-15T14:00:00")
+	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+	private LocalDateTime scheduledAt;
+
+	@Schema(description = "다운타임(일)", example = "7")
+	private Integer downtimeDays;
+
+	@Schema(description = "민감기 날짜 목록", example = "[\"2025-01-15\", \"2025-01-16\", \"2025-01-17\"]")
+	@JsonFormat(pattern = "yyyy-MM-dd")
+	private List<LocalDate> sensitiveDays;
+
+	@Schema(description = "주의기 날짜 목록", example = "[\"2025-01-18\", \"2025-01-19\"]")
+	@JsonFormat(pattern = "yyyy-MM-dd")
+	private List<LocalDate> cautionDays;
+
+	@Schema(description = "회복기 날짜 목록", example = "[\"2025-01-20\", \"2025-01-21\"]")
+	@JsonFormat(pattern = "yyyy-MM-dd")
+	private List<LocalDate> recoveryDays;
+
+	public static ProcedureEventResponseDto from(UserProcedure userProcedure) {
+		LocalDate scheduledDate = userProcedure.getScheduledAt().toLocalDate();
+		Integer downtimeDays = userProcedure.getDowntimeDays();
+
+		// 다운타임이 null이거나 0이면 모든 날짜 목록을 빈 리스트로
+		if (downtimeDays == null || downtimeDays == 0) {
+			return ProcedureEventResponseDto.builder()
+				.type(CalendarEventType.PROCEDURE)
+				.id(userProcedure.getId())
+				.procedureId(userProcedure.getProcedure().getId())
+				.name(userProcedure.getProcedure().getName())
+				.scheduledAt(userProcedure.getScheduledAt())
+				.downtimeDays(downtimeDays)
+				.sensitiveDays(List.of())
+				.cautionDays(List.of())
+				.recoveryDays(List.of())
+				.build();
+		}
+
+		// 다운타임을 3으로 나누어 기간 계산
+		int baseDays = downtimeDays / 3;
+		int remainder = downtimeDays % 3;
+
+		int sensitiveDaysCount = baseDays + (remainder >= 1 ? 1 : 0);
+		int cautionDaysCount = baseDays + (remainder >= 2 ? 1 : 0);
+		int recoveryDaysCount = baseDays;
+
+		// 날짜 목록 생성
+		List<LocalDate> sensitiveDays = generateDateRange(scheduledDate, sensitiveDaysCount);
+		List<LocalDate> cautionDays = generateDateRange(scheduledDate.plusDays(sensitiveDaysCount),
+			cautionDaysCount);
+		List<LocalDate> recoveryDays = generateDateRange(
+			scheduledDate.plusDays(sensitiveDaysCount + cautionDaysCount), recoveryDaysCount);
+
+		return ProcedureEventResponseDto.builder()
+			.type(CalendarEventType.PROCEDURE)
+			.id(userProcedure.getId())
+			.procedureId(userProcedure.getProcedure().getId())
+			.name(userProcedure.getProcedure().getName())
+			.scheduledAt(userProcedure.getScheduledAt())
+			.downtimeDays(downtimeDays)
+			.sensitiveDays(sensitiveDays)
+			.cautionDays(cautionDays)
+			.recoveryDays(recoveryDays)
+			.build();
+	}
+
+	private static List<LocalDate> generateDateRange(LocalDate startDate, int days) {
+		if (days <= 0) {
+			return List.of();
+		}
+		return java.util.stream.IntStream.range(0, days)
+			.mapToObj(startDate::plusDays)
+			.toList();
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/calendar/presentation/dto/response/ProcedureEventResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/calendar/presentation/dto/response/ProcedureEventResponseDto.java
@@ -30,22 +30,22 @@ public class ProcedureEventResponseDto {
 	@Schema(description = "시술명", example = "레이저 토닝")
 	private String name;
 
-	@Schema(description = "예약 날짜 및 시간", example = "2025-01-15T14:00:00")
+	@Schema(description = "예약 날짜 및 시간", example = "2026-01-15T14:00:00")
 	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
 	private LocalDateTime scheduledAt;
 
 	@Schema(description = "다운타임(일)", example = "7")
 	private Integer downtimeDays;
 
-	@Schema(description = "민감기 날짜 목록", example = "[\"2025-01-15\", \"2025-01-16\", \"2025-01-17\"]")
+	@Schema(description = "민감기 날짜 목록", example = "[\"2026-01-15\", \"2026-01-16\", \"2026-01-17\"]")
 	@JsonFormat(pattern = "yyyy-MM-dd")
 	private List<LocalDate> sensitiveDays;
 
-	@Schema(description = "주의기 날짜 목록", example = "[\"2025-01-18\", \"2025-01-19\"]")
+	@Schema(description = "주의기 날짜 목록", example = "[\"2026-01-18\", \"2026-01-19\"]")
 	@JsonFormat(pattern = "yyyy-MM-dd")
 	private List<LocalDate> cautionDays;
 
-	@Schema(description = "회복기 날짜 목록", example = "[\"2025-01-20\", \"2025-01-21\"]")
+	@Schema(description = "회복기 날짜 목록", example = "[\"2026-01-20\", \"2026-01-21\"]")
 	@JsonFormat(pattern = "yyyy-MM-dd")
 	private List<LocalDate> recoveryDays;
 

--- a/src/main/java/com/sopt/cherrish/domain/calendar/presentation/dto/response/ProcedureEventResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/calendar/presentation/dto/response/ProcedureEventResponseDto.java
@@ -5,6 +5,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 import com.sopt.cherrish.domain.calendar.domain.model.CalendarEventType;
 import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
 import com.sopt.cherrish.domain.userprocedure.domain.vo.DowntimePeriod;
@@ -38,15 +40,15 @@ public class ProcedureEventResponseDto {
 	private Integer downtimeDays;
 
 	@Schema(description = "민감기 날짜 목록", example = "[\"2026-01-15\", \"2026-01-16\", \"2026-01-17\"]")
-	@JsonFormat(pattern = "yyyy-MM-dd")
+	@JsonSerialize(contentUsing = LocalDateSerializer.class)
 	private List<LocalDate> sensitiveDays;
 
 	@Schema(description = "주의기 날짜 목록", example = "[\"2026-01-18\", \"2026-01-19\"]")
-	@JsonFormat(pattern = "yyyy-MM-dd")
+	@JsonSerialize(contentUsing = LocalDateSerializer.class)
 	private List<LocalDate> cautionDays;
 
 	@Schema(description = "회복기 날짜 목록", example = "[\"2026-01-20\", \"2026-01-21\"]")
-	@JsonFormat(pattern = "yyyy-MM-dd")
+	@JsonSerialize(contentUsing = LocalDateSerializer.class)
 	private List<LocalDate> recoveryDays;
 
 	public static ProcedureEventResponseDto from(UserProcedure userProcedure) {

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/model/UserProcedure.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/model/UserProcedure.java
@@ -42,7 +42,7 @@ public class UserProcedure extends BaseTimeEntity {
 	@Column(nullable = false, name = "scheduled_at")
 	private LocalDateTime scheduledAt;
 
-	@Column(name = "downtime_days")
+	@Column(name = "downtime_days", nullable = false)
 	private Integer downtimeDays;
 
 	@Builder

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/model/UserProcedure.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/model/UserProcedure.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
 import com.sopt.cherrish.domain.user.domain.model.User;
+import com.sopt.cherrish.domain.userprocedure.domain.vo.DowntimePeriod;
 import com.sopt.cherrish.global.entity.BaseTimeEntity;
 
 import jakarta.persistence.Column;
@@ -50,5 +51,15 @@ public class UserProcedure extends BaseTimeEntity {
 		this.procedure = procedure;
 		this.scheduledAt = scheduledAt;
 		this.downtimeDays = downtimeDays;
+	}
+
+	/**
+	 * 다운타임 기간 계산
+	 * 시술 시작일로부터 민감기/주의기/회복기를 계산합니다.
+	 *
+	 * @return 다운타임 기간 (민감기, 주의기, 회복기 날짜 목록)
+	 */
+	public DowntimePeriod calculateDowntimePeriod() {
+		return DowntimePeriod.calculate(this.downtimeDays, this.scheduledAt.toLocalDate());
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepository.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepository.java
@@ -4,5 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
 
-public interface UserProcedureRepository extends JpaRepository<UserProcedure, Long> {
+public interface UserProcedureRepository extends JpaRepository<UserProcedure, Long>,
+	UserProcedureRepositoryCustom {
 }

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryCustom.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryCustom.java
@@ -1,0 +1,27 @@
+package com.sopt.cherrish.domain.userprocedure.domain.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
+
+public interface UserProcedureRepositoryCustom {
+
+	/**
+	 * 특정 연월의 일자별 시술 개수 조회
+	 * @param userId 사용자 ID
+	 * @param year 연도
+	 * @param month 월
+	 * @return Map<일자, 시술 개수>
+	 */
+	Map<Integer, Long> findMonthlyProcedureCounts(Long userId, int year, int month);
+
+	/**
+	 * 특정 날짜의 시술 목록 조회
+	 * @param userId 사용자 ID
+	 * @param date 날짜
+	 * @return 시술 목록
+	 */
+	List<UserProcedure> findDailyProcedures(Long userId, LocalDate date);
+}

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryImpl.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryImpl.java
@@ -1,0 +1,59 @@
+package com.sopt.cherrish.domain.userprocedure.domain.repository;
+
+import static com.sopt.cherrish.domain.userprocedure.domain.model.QUserProcedure.userProcedure;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class UserProcedureRepositoryImpl implements UserProcedureRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Map<Integer, Long> findMonthlyProcedureCounts(Long userId, int year, int month) {
+		LocalDateTime startOfMonth = LocalDateTime.of(year, month, 1, 0, 0, 0);
+		LocalDateTime endOfMonth = startOfMonth.plusMonths(1);
+
+		List<UserProcedure> procedures = queryFactory
+			.selectFrom(userProcedure)
+			.where(
+				userProcedure.user.id.eq(userId),
+				userProcedure.scheduledAt.goe(startOfMonth),
+				userProcedure.scheduledAt.lt(endOfMonth)
+			)
+			.fetch();
+
+		// 일자별로 그룹핑하여 개수 집계
+		return procedures.stream()
+			.collect(Collectors.groupingBy(
+				procedure -> procedure.getScheduledAt().getDayOfMonth(),
+				Collectors.counting()
+			));
+	}
+
+	@Override
+	public List<UserProcedure> findDailyProcedures(Long userId, LocalDate date) {
+		LocalDateTime startOfDay = date.atStartOfDay();
+		LocalDateTime endOfDay = date.plusDays(1).atStartOfDay();
+
+		return queryFactory
+			.selectFrom(userProcedure)
+			.join(userProcedure.procedure).fetchJoin()
+			.where(
+				userProcedure.user.id.eq(userId),
+				userProcedure.scheduledAt.goe(startOfDay),
+				userProcedure.scheduledAt.lt(endOfDay)
+			)
+			.orderBy(userProcedure.scheduledAt.asc())
+			.fetch();
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/vo/DowntimePeriod.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/vo/DowntimePeriod.java
@@ -1,0 +1,79 @@
+package com.sopt.cherrish.domain.userprocedure.domain.vo;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 다운타임 기간을 표현하는 Value Object
+ * 다운타임은 민감기 -> 주의기 -> 회복기 순서로 구성됩니다.
+ */
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DowntimePeriod {
+
+	private static final int PERIOD_COUNT = 3;
+	private static final DowntimePeriod EMPTY = new DowntimePeriod(List.of(), List.of(), List.of());
+
+	private final List<LocalDate> sensitiveDays;
+	private final List<LocalDate> cautionDays;
+	private final List<LocalDate> recoveryDays;
+
+	/**
+	 * 다운타임이 없는 빈 기간 반환
+	 */
+	public static DowntimePeriod empty() {
+		return EMPTY;
+	}
+
+	/**
+	 * 다운타임 일수와 시작 날짜로부터 다운타임 기간 계산
+	 *
+	 * @param downtimeDays 총 다운타임 일수
+	 * @param startDate 시술 시작 날짜
+	 * @return 계산된 다운타임 기간
+	 */
+	public static DowntimePeriod calculate(Integer downtimeDays, LocalDate startDate) {
+		if (downtimeDays == null || downtimeDays <= 0) {
+			return empty();
+		}
+
+		// 다운타임을 3으로 나누어 기간 계산 (민감기, 주의기, 회복기)
+		int baseDays = downtimeDays / PERIOD_COUNT;
+		int remainder = downtimeDays % PERIOD_COUNT;
+
+		int sensitiveDaysCount = baseDays + (remainder >= 1 ? 1 : 0);
+		int cautionDaysCount = baseDays + (remainder >= 2 ? 1 : 0);
+		int recoveryDaysCount = baseDays;
+
+		// 각 기간의 날짜 목록 생성
+		List<LocalDate> sensitiveDays = generateDateRange(startDate, sensitiveDaysCount);
+		List<LocalDate> cautionDays = generateDateRange(startDate.plusDays(sensitiveDaysCount), cautionDaysCount);
+		List<LocalDate> recoveryDays = generateDateRange(
+			startDate.plusDays(sensitiveDaysCount + cautionDaysCount),
+			recoveryDaysCount
+		);
+
+		return new DowntimePeriod(sensitiveDays, cautionDays, recoveryDays);
+	}
+
+	private static List<LocalDate> generateDateRange(LocalDate startDate, int days) {
+		if (days <= 0) {
+			return List.of();
+		}
+		return IntStream.range(0, days)
+			.mapToObj(startDate::plusDays)
+			.toList();
+	}
+
+	/**
+	 * 다운타임 기간이 비어있는지 확인
+	 */
+	public boolean isEmpty() {
+		return sensitiveDays.isEmpty() && cautionDays.isEmpty() && recoveryDays.isEmpty();
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/vo/DowntimePeriod.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/vo/DowntimePeriod.java
@@ -4,6 +4,9 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.IntStream;
 
+import com.sopt.cherrish.domain.userprocedure.exception.UserProcedureErrorCode;
+import com.sopt.cherrish.domain.userprocedure.exception.UserProcedureException;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,6 +20,8 @@ import lombok.Getter;
 public class DowntimePeriod {
 
 	private static final int PERIOD_COUNT = 3;
+	private static final int MIN_DOWNTIME_DAYS = 0;
+	private static final int MAX_DOWNTIME_DAYS = 30;
 	private static final DowntimePeriod EMPTY = new DowntimePeriod(List.of(), List.of(), List.of());
 
 	private final List<LocalDate> sensitiveDays;
@@ -33,12 +38,15 @@ public class DowntimePeriod {
 	/**
 	 * 다운타임 일수와 시작 날짜로부터 다운타임 기간 계산
 	 *
-	 * @param downtimeDays 총 다운타임 일수
+	 * @param downtimeDays 총 다운타임 일수 (0~30일)
 	 * @param startDate 시술 시작 날짜
 	 * @return 계산된 다운타임 기간
+	 * @throws UserProcedureException 다운타임 일수가 유효 범위를 벗어난 경우
 	 */
-	public static DowntimePeriod calculate(Integer downtimeDays, LocalDate startDate) {
-		if (downtimeDays == null || downtimeDays <= 0) {
+	public static DowntimePeriod calculate(int downtimeDays, LocalDate startDate) {
+		validateDowntimeDays(downtimeDays);
+
+		if (downtimeDays == 0) {
 			return empty();
 		}
 
@@ -68,6 +76,18 @@ public class DowntimePeriod {
 		return IntStream.range(0, days)
 			.mapToObj(startDate::plusDays)
 			.toList();
+	}
+
+	/**
+	 * 다운타임 일수 유효성 검증 (방어적 프로그래밍)
+	 *
+	 * @param downtimeDays 검증할 다운타임 일수
+	 * @throws UserProcedureException 다운타임 일수가 유효 범위(0~30일)를 벗어난 경우
+	 */
+	private static void validateDowntimeDays(int downtimeDays) {
+		if (downtimeDays < MIN_DOWNTIME_DAYS || downtimeDays > MAX_DOWNTIME_DAYS) {
+			throw new UserProcedureException(UserProcedureErrorCode.INVALID_DOWNTIME_DAYS);
+		}
 	}
 
 	/**

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/exception/UserProcedureErrorCode.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/exception/UserProcedureErrorCode.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum UserProcedureErrorCode implements ErrorType {
 	// UserProcedure 도메인 에러 (UP001 ~ UP099)
-	USER_PROCEDURE_NOT_FOUND("UP001", "사용자 시술 일정을 찾을 수 없습니다", 404);
+	USER_PROCEDURE_NOT_FOUND("UP001", "사용자 시술 일정을 찾을 수 없습니다", 404),
+	INVALID_DOWNTIME_DAYS("UP002", "다운타임 일수는 0일 이상 30일 이하여야 합니다", 400);
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/exception/UserProcedureErrorCode.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/exception/UserProcedureErrorCode.java
@@ -8,8 +8,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum UserProcedureErrorCode implements ErrorType {
 	// UserProcedure 도메인 에러 (UP001 ~ UP099)
-	USER_PROCEDURE_NOT_FOUND("UP001", "사용자 시술 일정을 찾을 수 없습니다", 404),
-	INVALID_DOWNTIME_DAYS("UP002", "다운타임 일수는 0일 이상 30일 이하여야 합니다", 400);
+	INVALID_DOWNTIME_DAYS("UP001", "다운타임 일수는 0일 이상 30일 이하여야 합니다", 400);
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/UserProcedureController.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/UserProcedureController.java
@@ -24,7 +24,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/users/procedures")
+@RequestMapping("/api/user-procedures")
 @RequiredArgsConstructor
 @Tag(name = "UserProcedure", description = "사용자 시술 일정 API")
 public class UserProcedureController {

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/request/UserProcedureCreateRequestItemDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/request/UserProcedureCreateRequestItemDto.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -21,7 +22,8 @@ public class UserProcedureCreateRequestItemDto {
 
 	@Schema(description = "개인 다운타임(일)", example = "6", requiredMode = Schema.RequiredMode.REQUIRED)
 	@NotNull(message = "개인 다운타임은 필수입니다")
-	@Min(value = 0, message = "다운타임은 0 이상이어야 합니다")
+	@Min(value = 0, message = "다운타임은 0일 이상이어야 합니다")
+	@Max(value = 30, message = "다운타임은 30일 이하여야 합니다")
 	private Integer downtimeDays;
 
 	@JsonCreator

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/response/UserProcedureResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/response/UserProcedureResponseDto.java
@@ -23,7 +23,7 @@ public class UserProcedureResponseDto {
 	@Schema(description = "시술명", example = "레이저 토닝")
 	private String procedureName;
 
-	@Schema(description = "예약 날짜 및 시간", example = "2025-01-01T16:00:00", type = "string")
+	@Schema(description = "예약 날짜 및 시간", example = "2026-01-01T16:00:00", type = "string")
 	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
 	private LocalDateTime scheduledAt;
 

--- a/src/test/java/com/sopt/cherrish/domain/calendar/application/service/CalendarServiceTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/calendar/application/service/CalendarServiceTest.java
@@ -1,0 +1,274 @@
+package com.sopt.cherrish.domain.calendar.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sopt.cherrish.domain.calendar.presentation.dto.response.CalendarDailyResponseDto;
+import com.sopt.cherrish.domain.calendar.presentation.dto.response.CalendarMonthlyResponseDto;
+import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
+import com.sopt.cherrish.domain.user.domain.model.User;
+import com.sopt.cherrish.domain.user.domain.repository.UserRepository;
+import com.sopt.cherrish.domain.user.exception.UserErrorCode;
+import com.sopt.cherrish.domain.user.exception.UserException;
+import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
+import com.sopt.cherrish.domain.userprocedure.domain.repository.UserProcedureRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CalendarService 단위 테스트")
+class CalendarServiceTest {
+
+	@InjectMocks
+	private CalendarService calendarService;
+
+	@Mock
+	private UserProcedureRepository userProcedureRepository;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Test
+	@DisplayName("월별 캘린더 조회 성공")
+	void getMonthlyCalendarSuccess() {
+		// given
+		Long userId = 1L;
+		int year = 2025;
+		int month = 1;
+
+		Map<Integer, Long> mockCounts = Map.of(
+			1, 2L,
+			5, 1L,
+			10, 3L
+		);
+
+		given(userRepository.existsById(userId)).willReturn(true);
+		given(userProcedureRepository.findMonthlyProcedureCounts(userId, year, month))
+			.willReturn(mockCounts);
+
+		// when
+		CalendarMonthlyResponseDto result = calendarService.getMonthlyCalendar(userId, year, month);
+
+			// then
+			assertThat(result).isNotNull();
+			assertThat(result.getDailyProcedureCounts()).hasSize(3);
+			assertThat(result.getDailyProcedureCounts().get(1)).isEqualTo(2L);
+			assertThat(result.getDailyProcedureCounts().get(5)).isEqualTo(1L);
+			assertThat(result.getDailyProcedureCounts().get(10)).isEqualTo(3L);
+	}
+
+	@Test
+	@DisplayName("월별 캘린더 조회 실패 - 존재하지 않는 사용자")
+	void getMonthlyCalendarUserNotFound() {
+		// given
+		Long userId = 999L;
+		int year = 2025;
+		int month = 1;
+
+		given(userRepository.existsById(userId)).willReturn(false);
+
+		// when & then
+		assertThatThrownBy(() -> calendarService.getMonthlyCalendar(userId, year, month))
+			.isInstanceOf(UserException.class)
+			.hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_NOT_FOUND);
+	}
+
+	@Test
+	@DisplayName("일자별 시술 상세 조회 성공")
+	void getDailyCalendarSuccess() {
+		// given
+		Long userId = 1L;
+		LocalDate date = LocalDate.of(2025, 1, 15);
+
+		User mockUser = User.builder()
+			.name("테스트 사용자")
+			.age(25)
+			.build();
+
+		Procedure mockProcedure1 = Procedure.builder()
+			.name("레이저 토닝")
+			.build();
+
+		Procedure mockProcedure2 = Procedure.builder()
+			.name("필러")
+			.build();
+
+		UserProcedure userProcedure1 = UserProcedure.builder()
+			.user(mockUser)
+			.procedure(mockProcedure1)
+			.scheduledAt(LocalDateTime.of(2025, 1, 15, 14, 0))
+			.downtimeDays(9)
+			.build();
+
+		UserProcedure userProcedure2 = UserProcedure.builder()
+			.user(mockUser)
+			.procedure(mockProcedure2)
+			.scheduledAt(LocalDateTime.of(2025, 1, 15, 16, 0))
+			.downtimeDays(6)
+			.build();
+
+		given(userRepository.existsById(userId)).willReturn(true);
+		given(userProcedureRepository.findDailyProcedures(userId, date))
+			.willReturn(List.of(userProcedure1, userProcedure2));
+
+		// when
+		CalendarDailyResponseDto result = calendarService.getDailyCalendar(userId, date);
+
+			// then
+			assertThat(result).isNotNull();
+			assertThat(result.getEventCount()).isEqualTo(2);
+			assertThat(result.getEvents()).hasSize(2);
+
+			// 첫 번째 시술 검증 (다운타임 9일 -> 민감기 3일, 주의기 3일, 회복기 3일)
+			assertThat(result.getEvents().get(0).getName()).isEqualTo("레이저 토닝");
+			assertThat(result.getEvents().get(0).getDowntimeDays()).isEqualTo(9);
+			assertThat(result.getEvents().get(0).getSensitiveDays()).hasSize(3);
+			assertThat(result.getEvents().get(0).getCautionDays()).hasSize(3);
+			assertThat(result.getEvents().get(0).getRecoveryDays()).hasSize(3);
+
+			// 두 번째 시술 검증 (다운타임 6일 -> 민감기 2일, 주의기 2일, 회복기 2일)
+			assertThat(result.getEvents().get(1).getName()).isEqualTo("필러");
+			assertThat(result.getEvents().get(1).getDowntimeDays()).isEqualTo(6);
+			assertThat(result.getEvents().get(1).getSensitiveDays()).hasSize(2);
+			assertThat(result.getEvents().get(1).getCautionDays()).hasSize(2);
+			assertThat(result.getEvents().get(1).getRecoveryDays()).hasSize(2);
+	}
+
+	@Test
+	@DisplayName("일자별 시술 상세 조회 성공 - 다운타임 나머지 처리 확인 (7일)")
+	void getDailyCalendarDowntimeRemainder1() {
+		// given
+		Long userId = 1L;
+		LocalDate date = LocalDate.of(2025, 1, 15);
+
+		User mockUser = User.builder()
+			.name("테스트 사용자")
+			.age(25)
+			.build();
+
+		Procedure mockProcedure = Procedure.builder()
+			.name("레이저 토닝")
+			.build();
+
+		// 다운타임 7일 -> 7 / 3 = 2...1 -> 민감기 3일, 주의기 2일, 회복기 2일
+		UserProcedure userProcedure = UserProcedure.builder()
+			.user(mockUser)
+			.procedure(mockProcedure)
+			.scheduledAt(LocalDateTime.of(2025, 1, 15, 14, 0))
+			.downtimeDays(7)
+			.build();
+
+		given(userRepository.existsById(userId)).willReturn(true);
+		given(userProcedureRepository.findDailyProcedures(userId, date))
+			.willReturn(List.of(userProcedure));
+
+		// when
+		CalendarDailyResponseDto result = calendarService.getDailyCalendar(userId, date);
+
+			// then
+			assertThat(result.getEvents().get(0).getSensitiveDays()).hasSize(3);
+			assertThat(result.getEvents().get(0).getCautionDays()).hasSize(2);
+			assertThat(result.getEvents().get(0).getRecoveryDays()).hasSize(2);
+	}
+
+	@Test
+	@DisplayName("일자별 시술 상세 조회 성공 - 다운타임 나머지 처리 확인 (8일)")
+	void getDailyCalendarDowntimeRemainder2() {
+		// given
+		Long userId = 1L;
+		LocalDate date = LocalDate.of(2025, 1, 15);
+
+		User mockUser = User.builder()
+			.name("테스트 사용자")
+			.age(25)
+			.build();
+
+		Procedure mockProcedure = Procedure.builder()
+			.name("레이저 토닝")
+			.build();
+
+		// 다운타임 8일 -> 8 / 3 = 2...2 -> 민감기 3일, 주의기 3일, 회복기 2일
+		UserProcedure userProcedure = UserProcedure.builder()
+			.user(mockUser)
+			.procedure(mockProcedure)
+			.scheduledAt(LocalDateTime.of(2025, 1, 15, 14, 0))
+			.downtimeDays(8)
+			.build();
+
+		given(userRepository.existsById(userId)).willReturn(true);
+		given(userProcedureRepository.findDailyProcedures(userId, date))
+			.willReturn(List.of(userProcedure));
+
+		// when
+		CalendarDailyResponseDto result = calendarService.getDailyCalendar(userId, date);
+
+			// then
+			assertThat(result.getEvents().get(0).getSensitiveDays()).hasSize(3);
+			assertThat(result.getEvents().get(0).getCautionDays()).hasSize(3);
+			assertThat(result.getEvents().get(0).getRecoveryDays()).hasSize(2);
+	}
+
+	@Test
+	@DisplayName("일자별 시술 상세 조회 성공 - 다운타임 0일 (빈 리스트)")
+	void getDailyCalendarZeroDowntime() {
+		// given
+		Long userId = 1L;
+		LocalDate date = LocalDate.of(2025, 1, 15);
+
+		User mockUser = User.builder()
+			.name("테스트 사용자")
+			.age(25)
+			.build();
+
+		Procedure mockProcedure = Procedure.builder()
+			.name("레이저 토닝")
+			.build();
+
+		// 다운타임 0일
+		UserProcedure userProcedure = UserProcedure.builder()
+			.user(mockUser)
+			.procedure(mockProcedure)
+			.scheduledAt(LocalDateTime.of(2025, 1, 15, 14, 0))
+			.downtimeDays(0)
+			.build();
+
+		given(userRepository.existsById(userId)).willReturn(true);
+		given(userProcedureRepository.findDailyProcedures(userId, date))
+			.willReturn(List.of(userProcedure));
+
+		// when
+		CalendarDailyResponseDto result = calendarService.getDailyCalendar(userId, date);
+
+		// then
+		assertThat(result.getEvents().get(0).getDowntimeDays()).isEqualTo(0);
+		assertThat(result.getEvents().get(0).getSensitiveDays()).isEmpty();
+		assertThat(result.getEvents().get(0).getCautionDays()).isEmpty();
+		assertThat(result.getEvents().get(0).getRecoveryDays()).isEmpty();
+	}
+
+	@Test
+	@DisplayName("일자별 시술 상세 조회 실패 - 존재하지 않는 사용자")
+	void getDailyCalendarUserNotFound() {
+		// given
+		Long userId = 999L;
+		LocalDate date = LocalDate.of(2025, 1, 15);
+
+		given(userRepository.existsById(userId)).willReturn(false);
+
+		// when & then
+		assertThatThrownBy(() -> calendarService.getDailyCalendar(userId, date))
+			.isInstanceOf(UserException.class)
+			.hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_NOT_FOUND);
+	}
+}

--- a/src/test/java/com/sopt/cherrish/domain/calendar/application/service/CalendarServiceTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/calendar/application/service/CalendarServiceTest.java
@@ -132,6 +132,26 @@ class CalendarServiceTest {
 		assertThat(result.getEvents().get(1).getRecoveryDays()).hasSize(2);
 	}
 
+	@Test
+	@DisplayName("일자별 시술 상세 조회 성공 - 시술 없음")
+	void getDailyCalendarSuccessWithNoProcedures() {
+		// given
+		Long userId = 1L;
+		LocalDate date = LocalDate.of(2025, 1, 15);
+
+		given(userRepository.existsById(userId)).willReturn(true);
+		given(userProcedureRepository.findDailyProcedures(userId, date))
+			.willReturn(List.of());
+
+		// when
+		CalendarDailyResponseDto result = calendarService.getDailyCalendar(userId, date);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getEventCount()).isZero();
+		assertThat(result.getEvents()).isEmpty();
+	}
+
 	@ParameterizedTest
 	@DisplayName("일자별 시술 상세 조회 성공 - 다운타임 기간 계산 검증")
 	@CsvSource({

--- a/src/test/java/com/sopt/cherrish/domain/calendar/fixture/CalendarTestFixture.java
+++ b/src/test/java/com/sopt/cherrish/domain/calendar/fixture/CalendarTestFixture.java
@@ -1,0 +1,67 @@
+package com.sopt.cherrish.domain.calendar.fixture;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.sopt.cherrish.domain.calendar.domain.model.CalendarEventType;
+import com.sopt.cherrish.domain.calendar.presentation.dto.response.CalendarDailyResponseDto;
+import com.sopt.cherrish.domain.calendar.presentation.dto.response.ProcedureEventResponseDto;
+import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
+import com.sopt.cherrish.domain.user.domain.model.User;
+import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
+
+public class CalendarTestFixture {
+
+	public static User createMockUser(String name, int age) {
+		return User.builder()
+			.name(name)
+			.age(age)
+			.build();
+	}
+
+	public static Procedure createMockProcedure(String name) {
+		return Procedure.builder()
+			.name(name)
+			.build();
+	}
+
+	public static UserProcedure createUserProcedure(
+		User user,
+		Procedure procedure,
+		LocalDateTime scheduledAt,
+		int downtimeDays
+	) {
+		return UserProcedure.builder()
+			.user(user)
+			.procedure(procedure)
+			.scheduledAt(scheduledAt)
+			.downtimeDays(downtimeDays)
+			.build();
+	}
+
+	public static CalendarDailyResponseDto createDailyResponseWithSingleEvent(
+		Long eventId,
+		Long procedureId,
+		String procedureName,
+		LocalDateTime scheduledAt,
+		int downtimeDays,
+		List<LocalDate> sensitiveDays,
+		List<LocalDate> cautionDays,
+		List<LocalDate> recoveryDays
+	) {
+		ProcedureEventResponseDto event = ProcedureEventResponseDto.builder()
+			.type(CalendarEventType.PROCEDURE)
+			.id(eventId)
+			.procedureId(procedureId)
+			.name(procedureName)
+			.scheduledAt(scheduledAt)
+			.downtimeDays(downtimeDays)
+			.sensitiveDays(sensitiveDays)
+			.cautionDays(cautionDays)
+			.recoveryDays(recoveryDays)
+			.build();
+
+		return CalendarDailyResponseDto.from(List.of(event));
+	}
+}

--- a/src/test/java/com/sopt/cherrish/domain/calendar/fixture/CalendarTestFixture.java
+++ b/src/test/java/com/sopt/cherrish/domain/calendar/fixture/CalendarTestFixture.java
@@ -13,6 +13,9 @@ import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
 
 public class CalendarTestFixture {
 
+	private CalendarTestFixture() {
+	}
+
 	public static User createMockUser(String name, int age) {
 		return User.builder()
 			.name(name)

--- a/src/test/java/com/sopt/cherrish/domain/calendar/presentation/CalendarControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/calendar/presentation/CalendarControllerTest.java
@@ -60,33 +60,32 @@ class CalendarControllerTest {
 			.andExpect(jsonPath("$.data.dailyProcedureCounts['10']").value(3));
 	}
 
-	// TODO: 전역 예외 처리 개선 후 주석 해제
-	// @Test
-	// @DisplayName("월별 캘린더 조회 실패 - year 파라미터 누락")
-	// void getMonthlyCalendarMissingYear() throws Exception {
-		// 	mockMvc.perform(get("/api/calendar/monthly")
-		// 			.header("X-User-Id", 1L)
-	// 			.param("month", "1"))
-	// 		.andExpect(status().isBadRequest());
-	// }
-	//
-	// @Test
-	// @DisplayName("월별 캘린더 조회 실패 - month 파라미터 누락")
-	// void getMonthlyCalendarMissingMonth() throws Exception {
-		// 	mockMvc.perform(get("/api/calendar/monthly")
-		// 			.header("X-User-Id", 1L)
-	// 			.param("year", "2025"))
-	// 		.andExpect(status().isBadRequest());
-	// }
-	//
-	// @Test
-		// @DisplayName("월별 캘린더 조회 실패 - X-User-Id 헤더 누락")
-	// void getMonthlyCalendarMissingUserId() throws Exception {
-	// 	mockMvc.perform(get("/api/calendar/monthly")
-	// 			.param("year", "2025")
-	// 			.param("month", "1"))
-	// 		.andExpect(status().isBadRequest());
-	// }
+	@Test
+	@DisplayName("월별 캘린더 조회 실패 - year 파라미터 누락")
+	void getMonthlyCalendarMissingYear() throws Exception {
+		mockMvc.perform(get("/api/calendar/monthly")
+				.header("X-User-Id", 1L)
+				.param("month", "1"))
+			.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	@DisplayName("월별 캘린더 조회 실패 - month 파라미터 누락")
+	void getMonthlyCalendarMissingMonth() throws Exception {
+		mockMvc.perform(get("/api/calendar/monthly")
+				.header("X-User-Id", 1L)
+				.param("year", "2025"))
+			.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	@DisplayName("월별 캘린더 조회 실패 - X-User-Id 헤더 누락")
+	void getMonthlyCalendarMissingUserId() throws Exception {
+		mockMvc.perform(get("/api/calendar/monthly")
+				.param("year", "2025")
+				.param("month", "1"))
+			.andExpect(status().isBadRequest());
+	}
 
 	@Test
 	@DisplayName("일자별 시술 상세 조회 성공")
@@ -139,29 +138,28 @@ class CalendarControllerTest {
 			.andExpect(jsonPath("$.data.events[0].recoveryDays.length()").value(3));
 	}
 
-	// TODO: 전역 예외 처리 개선 후 주석 해제
-	// @Test
-	// @DisplayName("일자별 시술 상세 조회 실패 - date 파라미터 누락")
-	// void getDailyCalendarMissingDate() throws Exception {
-		// 	mockMvc.perform(get("/api/calendar/daily")
-		// 			.header("X-User-Id", 1L))
-	// 		.andExpect(status().isBadRequest());
-	// }
-	//
-	// @Test
-		// @DisplayName("일자별 시술 상세 조회 실패 - X-User-Id 헤더 누락")
-	// void getDailyCalendarMissingUserId() throws Exception {
-	// 	mockMvc.perform(get("/api/calendar/daily")
-	// 			.param("date", "2025-01-15"))
-	// 		.andExpect(status().isBadRequest());
-	// }
-	//
-	// @Test
-	// @DisplayName("일자별 시술 상세 조회 실패 - date 형식 오류")
-	// void getDailyCalendarInvalidDateFormat() throws Exception {
-		// 	mockMvc.perform(get("/api/calendar/daily")
-		// 			.header("X-User-Id", 1L)
-		// 			.param("date", "2025/01/15"))
-	// 		.andExpect(status().isBadRequest());
-	// }
+	@Test
+	@DisplayName("일자별 시술 상세 조회 실패 - date 파라미터 누락")
+	void getDailyCalendarMissingDate() throws Exception {
+		mockMvc.perform(get("/api/calendar/daily")
+				.header("X-User-Id", 1L))
+			.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	@DisplayName("일자별 시술 상세 조회 실패 - X-User-Id 헤더 누락")
+	void getDailyCalendarMissingUserId() throws Exception {
+		mockMvc.perform(get("/api/calendar/daily")
+				.param("date", "2025-01-15"))
+			.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	@DisplayName("일자별 시술 상세 조회 실패 - date 형식 오류")
+	void getDailyCalendarInvalidDateFormat() throws Exception {
+		mockMvc.perform(get("/api/calendar/daily")
+				.header("X-User-Id", 1L)
+				.param("date", "2025/01/15"))
+			.andExpect(status().isBadRequest());
+	}
 }

--- a/src/test/java/com/sopt/cherrish/domain/calendar/presentation/CalendarControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/calendar/presentation/CalendarControllerTest.java
@@ -1,0 +1,170 @@
+package com.sopt.cherrish.domain.calendar.presentation;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.sopt.cherrish.domain.calendar.application.service.CalendarService;
+import com.sopt.cherrish.domain.calendar.domain.model.CalendarEventType;
+import com.sopt.cherrish.domain.calendar.presentation.dto.response.CalendarDailyResponseDto;
+import com.sopt.cherrish.domain.calendar.presentation.dto.response.CalendarMonthlyResponseDto;
+import com.sopt.cherrish.domain.calendar.presentation.dto.response.ProcedureEventResponseDto;
+
+@WebMvcTest(CalendarController.class)
+@DisplayName("CalendarController 통합 테스트")
+class CalendarControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private CalendarService calendarService;
+
+	@Test
+	@DisplayName("월별 캘린더 조회 성공")
+	void getMonthlyCalendarSuccess() throws Exception {
+		// given
+		Long userId = 1L;
+		int year = 2025;
+		int month = 1;
+
+		Map<Integer, Long> mockCounts = Map.of(
+			1, 2L,
+			5, 1L,
+			10, 3L
+		);
+
+		CalendarMonthlyResponseDto response = CalendarMonthlyResponseDto.from(mockCounts);
+		given(calendarService.getMonthlyCalendar(userId, year, month)).willReturn(response);
+
+		// when & then
+		mockMvc.perform(get("/api/calendar/monthly")
+				.header("X-User-Id", userId)
+				.param("year", String.valueOf(year))
+				.param("month", String.valueOf(month)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.dailyProcedureCounts['1']").value(2))
+			.andExpect(jsonPath("$.data.dailyProcedureCounts['5']").value(1))
+			.andExpect(jsonPath("$.data.dailyProcedureCounts['10']").value(3));
+	}
+
+	// TODO: 전역 예외 처리 개선 후 주석 해제
+	// @Test
+	// @DisplayName("월별 캘린더 조회 실패 - year 파라미터 누락")
+	// void getMonthlyCalendarMissingYear() throws Exception {
+		// 	mockMvc.perform(get("/api/calendar/monthly")
+		// 			.header("X-User-Id", 1L)
+	// 			.param("month", "1"))
+	// 		.andExpect(status().isBadRequest());
+	// }
+	//
+	// @Test
+	// @DisplayName("월별 캘린더 조회 실패 - month 파라미터 누락")
+	// void getMonthlyCalendarMissingMonth() throws Exception {
+		// 	mockMvc.perform(get("/api/calendar/monthly")
+		// 			.header("X-User-Id", 1L)
+	// 			.param("year", "2025"))
+	// 		.andExpect(status().isBadRequest());
+	// }
+	//
+	// @Test
+		// @DisplayName("월별 캘린더 조회 실패 - X-User-Id 헤더 누락")
+	// void getMonthlyCalendarMissingUserId() throws Exception {
+	// 	mockMvc.perform(get("/api/calendar/monthly")
+	// 			.param("year", "2025")
+	// 			.param("month", "1"))
+	// 		.andExpect(status().isBadRequest());
+	// }
+
+	@Test
+	@DisplayName("일자별 시술 상세 조회 성공")
+	void getDailyCalendarSuccess() throws Exception {
+		// given
+		Long userId = 1L;
+		LocalDate date = LocalDate.of(2025, 1, 15);
+
+		ProcedureEventResponseDto event1 = ProcedureEventResponseDto.builder()
+			.type(CalendarEventType.PROCEDURE)
+			.id(123L)
+			.procedureId(5L)
+			.name("레이저 토닝")
+			.scheduledAt(LocalDateTime.of(2025, 1, 15, 14, 0))
+			.downtimeDays(9)
+			.sensitiveDays(List.of(
+				LocalDate.of(2025, 1, 15),
+				LocalDate.of(2025, 1, 16),
+				LocalDate.of(2025, 1, 17)
+			))
+			.cautionDays(List.of(
+				LocalDate.of(2025, 1, 18),
+				LocalDate.of(2025, 1, 19),
+				LocalDate.of(2025, 1, 20)
+			))
+			.recoveryDays(List.of(
+				LocalDate.of(2025, 1, 21),
+				LocalDate.of(2025, 1, 22),
+				LocalDate.of(2025, 1, 23)
+			))
+			.build();
+
+		CalendarDailyResponseDto response = CalendarDailyResponseDto.from(List.of(event1));
+		given(calendarService.getDailyCalendar(userId, date)).willReturn(response);
+
+		// when & then
+		mockMvc.perform(get("/api/calendar/daily")
+				.header("X-User-Id", userId)
+				.param("date", "2025-01-15"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.eventCount").value(1))
+			.andExpect(jsonPath("$.data.events[0].type").value("PROCEDURE"))
+			.andExpect(jsonPath("$.data.events[0].id").value(123))
+			.andExpect(jsonPath("$.data.events[0].procedureId").value(5))
+			.andExpect(jsonPath("$.data.events[0].name").value("레이저 토닝"))
+			.andExpect(jsonPath("$.data.events[0].downtimeDays").value(9))
+			.andExpect(jsonPath("$.data.events[0].sensitiveDays").isArray())
+			.andExpect(jsonPath("$.data.events[0].sensitiveDays.length()").value(3))
+			.andExpect(jsonPath("$.data.events[0].cautionDays").isArray())
+			.andExpect(jsonPath("$.data.events[0].cautionDays.length()").value(3))
+			.andExpect(jsonPath("$.data.events[0].recoveryDays").isArray())
+			.andExpect(jsonPath("$.data.events[0].recoveryDays.length()").value(3));
+	}
+
+	// TODO: 전역 예외 처리 개선 후 주석 해제
+	// @Test
+	// @DisplayName("일자별 시술 상세 조회 실패 - date 파라미터 누락")
+	// void getDailyCalendarMissingDate() throws Exception {
+		// 	mockMvc.perform(get("/api/calendar/daily")
+		// 			.header("X-User-Id", 1L))
+	// 		.andExpect(status().isBadRequest());
+	// }
+	//
+	// @Test
+		// @DisplayName("일자별 시술 상세 조회 실패 - X-User-Id 헤더 누락")
+	// void getDailyCalendarMissingUserId() throws Exception {
+	// 	mockMvc.perform(get("/api/calendar/daily")
+	// 			.param("date", "2025-01-15"))
+	// 		.andExpect(status().isBadRequest());
+	// }
+	//
+	// @Test
+	// @DisplayName("일자별 시술 상세 조회 실패 - date 형식 오류")
+	// void getDailyCalendarInvalidDateFormat() throws Exception {
+		// 	mockMvc.perform(get("/api/calendar/daily")
+		// 			.header("X-User-Id", 1L)
+		// 			.param("date", "2025/01/15"))
+	// 		.andExpect(status().isBadRequest());
+	// }
+}

--- a/src/test/java/com/sopt/cherrish/domain/calendar/presentation/CalendarControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/calendar/presentation/CalendarControllerTest.java
@@ -1,5 +1,6 @@
 package com.sopt.cherrish.domain.calendar.presentation;
 
+import static com.sopt.cherrish.domain.calendar.fixture.CalendarTestFixture.createDailyResponseWithSingleEvent;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -18,10 +19,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.sopt.cherrish.domain.calendar.application.service.CalendarService;
-import com.sopt.cherrish.domain.calendar.domain.model.CalendarEventType;
 import com.sopt.cherrish.domain.calendar.presentation.dto.response.CalendarDailyResponseDto;
 import com.sopt.cherrish.domain.calendar.presentation.dto.response.CalendarMonthlyResponseDto;
-import com.sopt.cherrish.domain.calendar.presentation.dto.response.ProcedureEventResponseDto;
 
 @WebMvcTest(CalendarController.class)
 @DisplayName("CalendarController 통합 테스트")
@@ -96,31 +95,29 @@ class CalendarControllerTest {
 		Long userId = 1L;
 		LocalDate date = LocalDate.of(2025, 1, 15);
 
-		ProcedureEventResponseDto event1 = ProcedureEventResponseDto.builder()
-			.type(CalendarEventType.PROCEDURE)
-			.id(123L)
-			.procedureId(5L)
-			.name("레이저 토닝")
-			.scheduledAt(LocalDateTime.of(2025, 1, 15, 14, 0))
-			.downtimeDays(9)
-			.sensitiveDays(List.of(
+		CalendarDailyResponseDto response = createDailyResponseWithSingleEvent(
+			123L,
+			5L,
+			"레이저 토닝",
+			LocalDateTime.of(2025, 1, 15, 14, 0),
+			9,
+			List.of(
 				LocalDate.of(2025, 1, 15),
 				LocalDate.of(2025, 1, 16),
 				LocalDate.of(2025, 1, 17)
-			))
-			.cautionDays(List.of(
+			),
+			List.of(
 				LocalDate.of(2025, 1, 18),
 				LocalDate.of(2025, 1, 19),
 				LocalDate.of(2025, 1, 20)
-			))
-			.recoveryDays(List.of(
+			),
+			List.of(
 				LocalDate.of(2025, 1, 21),
 				LocalDate.of(2025, 1, 22),
 				LocalDate.of(2025, 1, 23)
-			))
-			.build();
+			)
+		);
 
-		CalendarDailyResponseDto response = CalendarDailyResponseDto.from(List.of(event1));
 		given(calendarService.getDailyCalendar(userId, date)).willReturn(response);
 
 		// when & then

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/domain/vo/DowntimePeriodTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/domain/vo/DowntimePeriodTest.java
@@ -1,0 +1,172 @@
+package com.sopt.cherrish.domain.userprocedure.domain.vo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.sopt.cherrish.domain.userprocedure.exception.UserProcedureErrorCode;
+import com.sopt.cherrish.domain.userprocedure.exception.UserProcedureException;
+
+@DisplayName("DowntimePeriod VO 단위 테스트")
+class DowntimePeriodTest {
+
+	@Test
+	@DisplayName("다운타임 0일 - 빈 기간 반환")
+	void calculateZeroDowntime() {
+		// given
+		int downtimeDays = 0;
+		LocalDate startDate = LocalDate.of(2025, 1, 15);
+
+		// when
+		DowntimePeriod result = DowntimePeriod.calculate(downtimeDays, startDate);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getSensitiveDays()).isEmpty();
+		assertThat(result.getCautionDays()).isEmpty();
+		assertThat(result.getRecoveryDays()).isEmpty();
+		assertThat(result.isEmpty()).isTrue();
+	}
+
+	@ParameterizedTest
+	@DisplayName("다운타임 3으로 나누어떨어지는 경우 - 균등 분배")
+	@CsvSource({
+		"3, 1, 1, 1",   // 3일 -> 1/1/1
+		"6, 2, 2, 2",   // 6일 -> 2/2/2
+		"9, 3, 3, 3",   // 9일 -> 3/3/3
+		"30, 10, 10, 10" // 30일 (최댓값) -> 10/10/10
+	})
+	void calculateEvenlyDivisible(int downtimeDays, int expectedSensitive, int expectedCaution,
+		int expectedRecovery) {
+		// given
+		LocalDate startDate = LocalDate.of(2025, 1, 15);
+
+		// when
+		DowntimePeriod result = DowntimePeriod.calculate(downtimeDays, startDate);
+
+		// then
+		assertThat(result.getSensitiveDays()).hasSize(expectedSensitive);
+		assertThat(result.getCautionDays()).hasSize(expectedCaution);
+		assertThat(result.getRecoveryDays()).hasSize(expectedRecovery);
+		assertThat(result.isEmpty()).isFalse();
+	}
+
+	@ParameterizedTest
+	@DisplayName("다운타임 나머지가 1인 경우 - 민감기에 1일 추가")
+	@CsvSource({
+		"1, 1, 0, 0",   // 1일 -> 1/0/0
+		"4, 2, 1, 1",   // 4일 -> 2/1/1
+		"7, 3, 2, 2",   // 7일 -> 3/2/2
+		"10, 4, 3, 3"   // 10일 -> 4/3/3
+	})
+	void calculateRemainder1(int downtimeDays, int expectedSensitive, int expectedCaution, int expectedRecovery) {
+		// given
+		LocalDate startDate = LocalDate.of(2025, 1, 15);
+
+		// when
+		DowntimePeriod result = DowntimePeriod.calculate(downtimeDays, startDate);
+
+		// then
+		assertThat(result.getSensitiveDays()).hasSize(expectedSensitive);
+		assertThat(result.getCautionDays()).hasSize(expectedCaution);
+		assertThat(result.getRecoveryDays()).hasSize(expectedRecovery);
+	}
+
+	@ParameterizedTest
+	@DisplayName("다운타임 나머지가 2인 경우 - 민감기/주의기에 각 1일 추가")
+	@CsvSource({
+		"2, 1, 1, 0",   // 2일 -> 1/1/0
+		"5, 2, 2, 1",   // 5일 -> 2/2/1
+		"8, 3, 3, 2",   // 8일 -> 3/3/2
+		"11, 4, 4, 3"   // 11일 -> 4/4/3
+	})
+	void calculateRemainder2(int downtimeDays, int expectedSensitive, int expectedCaution, int expectedRecovery) {
+		// given
+		LocalDate startDate = LocalDate.of(2025, 1, 15);
+
+		// when
+		DowntimePeriod result = DowntimePeriod.calculate(downtimeDays, startDate);
+
+		// then
+		assertThat(result.getSensitiveDays()).hasSize(expectedSensitive);
+		assertThat(result.getCautionDays()).hasSize(expectedCaution);
+		assertThat(result.getRecoveryDays()).hasSize(expectedRecovery);
+	}
+
+	@Test
+	@DisplayName("날짜 순서 검증 - 민감기 -> 주의기 -> 회복기 순서로 연속")
+	void validateDateSequence() {
+		// given
+		int downtimeDays = 9;
+		LocalDate startDate = LocalDate.of(2025, 1, 15);
+
+		// when
+		DowntimePeriod result = DowntimePeriod.calculate(downtimeDays, startDate);
+
+		// then
+		// 민감기: 1/15, 1/16, 1/17
+		assertThat(result.getSensitiveDays()).containsExactly(
+			LocalDate.of(2025, 1, 15),
+			LocalDate.of(2025, 1, 16),
+			LocalDate.of(2025, 1, 17)
+		);
+
+		// 주의기: 1/18, 1/19, 1/20
+		assertThat(result.getCautionDays()).containsExactly(
+			LocalDate.of(2025, 1, 18),
+			LocalDate.of(2025, 1, 19),
+			LocalDate.of(2025, 1, 20)
+		);
+
+		// 회복기: 1/21, 1/22, 1/23
+		assertThat(result.getRecoveryDays()).containsExactly(
+			LocalDate.of(2025, 1, 21),
+			LocalDate.of(2025, 1, 22),
+			LocalDate.of(2025, 1, 23)
+		);
+	}
+
+	@Test
+	@DisplayName("다운타임 음수 - 예외 발생")
+	void calculateNegativeDowntime() {
+		// given
+		int downtimeDays = -1;
+		LocalDate startDate = LocalDate.of(2025, 1, 15);
+
+		// when & then
+		assertThatThrownBy(() -> DowntimePeriod.calculate(downtimeDays, startDate))
+			.isInstanceOf(UserProcedureException.class)
+			.hasFieldOrPropertyWithValue("errorCode", UserProcedureErrorCode.INVALID_DOWNTIME_DAYS);
+	}
+
+	@Test
+	@DisplayName("다운타임 31일 이상 - 예외 발생")
+	void calculateExceedMaxDowntime() {
+		// given
+		int downtimeDays = 31;
+		LocalDate startDate = LocalDate.of(2025, 1, 15);
+
+		// when & then
+		assertThatThrownBy(() -> DowntimePeriod.calculate(downtimeDays, startDate))
+			.isInstanceOf(UserProcedureException.class)
+			.hasFieldOrPropertyWithValue("errorCode", UserProcedureErrorCode.INVALID_DOWNTIME_DAYS);
+	}
+
+	@Test
+	@DisplayName("empty() 메서드 - 항상 동일한 인스턴스 반환")
+	void emptyReturnsSameInstance() {
+		// when
+		DowntimePeriod empty1 = DowntimePeriod.empty();
+		DowntimePeriod empty2 = DowntimePeriod.empty();
+
+		// then
+		assertThat(empty1).isSameAs(empty2);
+		assertThat(empty1.isEmpty()).isTrue();
+	}
+}

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/presentation/UserProcedureControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/presentation/UserProcedureControllerTest.java
@@ -151,7 +151,7 @@ class UserProcedureControllerTest {
 				.andExpect(status().isBadRequest())
 				.andExpect(jsonPath("$.code").value("C001"))
 				.andExpect(jsonPath("$.message").value("입력값이 올바르지 않습니다"))
-				.andExpect(jsonPath("$.data['procedures[0].downtimeDays']").value("다운타임은 0 이상이어야 합니다"));
+				.andExpect(jsonPath("$.data['procedures[0].downtimeDays']").value("다운타임은 0일 이상이어야 합니다"));
 		}
 
 		@Test

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/presentation/UserProcedureControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/presentation/UserProcedureControllerTest.java
@@ -46,7 +46,7 @@ class UserProcedureControllerTest {
 	private UserProcedureService userProcedureService;
 
 	@Nested
-	@DisplayName("POST /api/users/procedures - 사용자 시술 일정 등록")
+	@DisplayName("POST /api/user-procedures - 사용자 시술 일정 등록")
 	class CreateUserProcedures {
 
 		@Test
@@ -61,7 +61,7 @@ class UserProcedureControllerTest {
 				.willReturn(response);
 
 			// when & then
-			mockMvc.perform(post("/api/users/procedures")
+			mockMvc.perform(post("/api/user-procedures")
 				.header("X-User-Id", userId)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
@@ -95,7 +95,7 @@ class UserProcedureControllerTest {
 				.willThrow(new UserException(UserErrorCode.USER_NOT_FOUND));
 
 			// when & then
-			mockMvc.perform(post("/api/users/procedures")
+			mockMvc.perform(post("/api/user-procedures")
 				.header("X-User-Id", userId)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
@@ -113,7 +113,7 @@ class UserProcedureControllerTest {
 				.willThrow(new ProcedureException(ProcedureErrorCode.PROCEDURE_NOT_FOUND));
 
 			// when & then
-			mockMvc.perform(post("/api/users/procedures")
+			mockMvc.perform(post("/api/user-procedures")
 				.header("X-User-Id", userId)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
@@ -127,7 +127,7 @@ class UserProcedureControllerTest {
 			String invalidRequest = createInvalidRequestWithEmptyProcedures();
 
 			// when & then
-			mockMvc.perform(post("/api/users/procedures")
+			mockMvc.perform(post("/api/user-procedures")
 				.header("X-User-Id", 1L)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(invalidRequest))
@@ -144,7 +144,7 @@ class UserProcedureControllerTest {
 			String invalidRequest = createInvalidRequestWithNegativeDowntime();
 
 			// when & then
-			mockMvc.perform(post("/api/users/procedures")
+			mockMvc.perform(post("/api/user-procedures")
 				.header("X-User-Id", 1L)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(invalidRequest))
@@ -161,7 +161,7 @@ class UserProcedureControllerTest {
 			String invalidRequest = createInvalidRequestMissingScheduledAt();
 
 			// when & then
-			mockMvc.perform(post("/api/users/procedures")
+			mockMvc.perform(post("/api/user-procedures")
 				.header("X-User-Id", 1L)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(invalidRequest))


### PR DESCRIPTION
# 🛠 Related issue 🛠
- closed #13 

# ✏️ Work Description ✏️
- 캘린더 조회 API 구현
  - GET /api/calendar/monthly(월별), GET /api/calendar/daily (일별)
  - Request DTO로 파라미터 분리 및 유효성 검증
  - Calendar 이벤트 타입 enum 추가
  - 캘린더 Response DTO 추가
- 다운타임 로직 개선
  - 다운타임 계산 로직을 VO로 캡슐화
  - 다운타임 비즈니스 로직을 Entity로 이동
  - 월별 조회 쿼리 성능 개선
- UserProcedure 연관 변경
  - UserProcedure 커스텀 레포지토리 추가
  - 다운타임 null 비허용 및 0~30일 검증 추가
  - 사용자 시술 추가 엔드포인트 수정
  - 사용하지 않는 에러코드 삭제
  - 문서 예시 날짜 2026년으로 변경
- 테스트
  - 캘린더 서비스 단위 테스트 추가
  - 다운타임 VO 테스트 추가
  - 캘린더 컨트롤러 통합 테스트 추가
  - CalendarTestFixture 적용 및 UserProcedureControllerTest 엔드포인트 변경 반영


# 📸 Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 캘린더 월별 조회 응답|<img width="241" height="167" alt="스크린샷 2026-01-11 오전 2 27 38" src="https://github.com/user-attachments/assets/65bf71e8-417d-4994-bd32-b61710be62e6" />|
| 캘린더 일별 조회 응답 |<img width="331" height="394" alt="스크린샷 2026-01-11 오전 2 28 16" src="https://github.com/user-attachments/assets/fd5dc194-4611-4529-8900-874fb979167b" />|

# 😅 Uncompleted Tasks 😅
- 


# 📢 To Reviewers 📢
- 캘린더는 UserProcedure와 연관성이 높아 관련 변경도 함께 포함되었습니다
- 사용자 시술 등록 엔드포인트 /api/user-procedures로 변경한 내용도 포함되었습니다

