### PR TITLE
[Task] 챌린지 조회 API 응답에 체리 레벨 이름 및 남은 루틴 개수 추가

### DIFF
--- a/src/main/java/com/sopt/cherrish/domain/challenge/core/domain/model/ChallengeStatistics.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/core/domain/model/ChallengeStatistics.java
@@ -169,4 +169,30 @@ public class ChallengeStatistics extends BaseTimeEntity {
 			this.totalRoutineCount += count;
 		}
 	}
+
+	/**
+	 * 다음 레벨까지 남은 루틴 개수 계산
+	 *
+	 * @return 남은 루틴 개수 (최대 레벨이면 0)
+	 */
+	public int getRemainingRoutinesToNextLevel() {
+		// 최대 레벨(4)이면 0 반환
+		if (cherryLevel >= 4) {
+			return 0;
+		}
+
+		// 다음 레벨 임계값 선택 (기존 상수 재활용)
+		double nextThreshold = switch (cherryLevel) {
+			case 1 -> LEVEL_2_THRESHOLD;  // 25.0
+			case 2 -> LEVEL_3_THRESHOLD;  // 50.0
+			case 3 -> LEVEL_4_THRESHOLD;  // 75.0
+			default -> 100.0;
+		};
+
+		// 다음 레벨까지 필요한 총 완료 개수 (올림)
+		int requiredCompletedCount = (int) Math.ceil(totalRoutineCount * nextThreshold / 100.0);
+
+		// 남은 개수 (음수 방지)
+		return Math.max(0, requiredCompletedCount - completedCount);
+	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/challenge/core/domain/model/CherryLevel.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/core/domain/model/CherryLevel.java
@@ -1,0 +1,47 @@
+package com.sopt.cherrish.domain.challenge.core.domain.model;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.sopt.cherrish.domain.challenge.core.exception.ChallengeErrorCode;
+import com.sopt.cherrish.domain.challenge.core.exception.ChallengeException;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 체리 레벨 enum
+ * 진행률에 따라 체리가 성장하는 단계를 표현
+ */
+@Getter
+@RequiredArgsConstructor
+public enum CherryLevel {
+
+	LEVEL_1(1, "새싹 체리"),    // 0-24%
+	LEVEL_2(2, "꽃핀 체리"),    // 25-49%
+	LEVEL_3(3, "열매 체리"),    // 50-74%
+	LEVEL_4(4, "완숙 체리");    // 75-100%
+
+	private final int level;
+	private final String name;
+
+	private static final Map<Integer, CherryLevel> LEVEL_MAP =
+		Arrays.stream(values())
+			.collect(Collectors.toMap(CherryLevel::getLevel, cherryLevel -> cherryLevel));
+
+	/**
+	 * 레벨 숫자로 CherryLevel 찾기
+	 *
+	 * @param level 체리 레벨 (1-4)
+	 * @return 해당하는 CherryLevel enum
+	 * @throws ChallengeException 존재하지 않는 레벨인 경우
+	 */
+	public static CherryLevel fromLevel(int level) {
+		CherryLevel cherryLevel = LEVEL_MAP.get(level);
+		if (cherryLevel == null) {
+			throw new ChallengeException(ChallengeErrorCode.INVALID_CHERRY_LEVEL);
+		}
+		return cherryLevel;
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/challenge/core/exception/ChallengeErrorCode.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/core/exception/ChallengeErrorCode.java
@@ -19,7 +19,8 @@ public enum ChallengeErrorCode implements ErrorType {
 	ROUTINES_FROM_DIFFERENT_CHALLENGES("CH008", "서로 다른 챌린지의 루틴은 함께 업데이트할 수 없습니다", 400),
 	DUPLICATE_ROUTINE_IDS("CH009", "중복된 루틴 ID가 포함되어 있습니다", 400),
 	CHALLENGE_NOT_ACTIVE("CH010", "비활성 챌린지에는 루틴을 추가할 수 없습니다", 400),
-	CUSTOM_ROUTINE_LIMIT_EXCEEDED("CH011", "최대로 추가할 수 있는 루틴은 20개입니다", 400);
+	CUSTOM_ROUTINE_LIMIT_EXCEEDED("CH011", "최대로 추가할 수 있는 루틴은 20개입니다", 400),
+	INVALID_CHERRY_LEVEL("CH012", "유효하지 않은 체리 레벨입니다 (1-4)", 400);
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/sopt/cherrish/domain/challenge/core/presentation/dto/response/ChallengeDetailResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/core/presentation/dto/response/ChallengeDetailResponseDto.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.sopt.cherrish.domain.challenge.core.domain.model.Challenge;
 import com.sopt.cherrish.domain.challenge.core.domain.model.ChallengeRoutine;
 import com.sopt.cherrish.domain.challenge.core.domain.model.ChallengeStatistics;
+import com.sopt.cherrish.domain.challenge.core.domain.model.CherryLevel;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -25,8 +26,14 @@ public record ChallengeDetailResponseDto(
 	@Schema(description = "체리 레벨 (1-4)", example = "2")
 	int cherryLevel,
 
+	@Schema(description = "현재 체리 레벨 이름", example = "꽃핀 체리")
+	String cherryLevelName,
+
 	@Schema(description = "현재 레벨 내 진척도 (%)", example = "50.0")
 	double progressToNextLevel,
+
+	@Schema(description = "다음 레벨까지 남은 루틴 개수", example = "3")
+	int remainingRoutinesToNextLevel,
 
 	@Schema(description = "오늘의 루틴 리스트")
 	List<ChallengeRoutineResponseDto> todayRoutines,
@@ -51,7 +58,9 @@ public record ChallengeDetailResponseDto(
 			currentDay,
 			statistics.getProgressPercentage(),
 			statistics.getCherryLevel(),
+			CherryLevel.fromLevel(statistics.getCherryLevel()).getName(),
 			statistics.getProgressToNextLevel(),
+			statistics.getRemainingRoutinesToNextLevel(),
 			routineDtos,
 			cheeringMessage
 		);

--- a/src/test/java/com/sopt/cherrish/domain/challenge/core/fixture/ChallengeTestFixture.java
+++ b/src/test/java/com/sopt/cherrish/domain/challenge/core/fixture/ChallengeTestFixture.java
@@ -146,7 +146,9 @@ public class ChallengeTestFixture {
 			3,
 			42.5,
 			2,
+			"꽃핀 체리",
 			50.0,
+			3,
 			todayRoutines,
 			"3일차 루틴입니다. 오늘도 피부를 위해 힘내봐요!"
 		);


### PR DESCRIPTION
  # 🛠 Related issue 🛠
  - closed #55

  # ✏️ Work Description ✏️
  - 체리 레벨 이름 관리 기능 추가
      - `CherryLevel` Enum 생성 (레벨별 이름 정의)
      - 임시 이름이며 추후 확정되면 변경 예정입니다.
      - LEVEL_1: "새싹 체리" (0-24%)
      - LEVEL_2: "꽃핀 체리" (25-49%)
      - LEVEL_3: "열매 체리" (50-74%)
      - LEVEL_4: "완숙 체리" (75-100%)

  - 다음 레벨까지 남은 루틴 개수 계산 기능 추가
      - `ChallengeStatistics.getRemainingRoutinesToNextLevel()` 메서드 구현
      - 기존 상수(LEVEL_2_THRESHOLD, LEVEL_3_THRESHOLD, LEVEL_4_THRESHOLD) 재활용
      - 직접 루틴 개수 계산으로 성능 최적화
      - 최대 레벨 도달 시 0 반환

  - 챌린지 조회 API 응답 개선
      - `ChallengeDetailResponseDto`에 `cherryLevelName` 필드 추가
      - `ChallengeDetailResponseDto`에 `remainingRoutinesToNextLevel` 필드 추가

  - 에러 처리 추가
      - `ChallengeErrorCode`에 `INVALID_CHERRY_LEVEL` (CH012) 추가

  # 📸 Screenshot 📸
  |              설명               |     사진      |
  |:-----------------------------:|:-----------:|
  | 챌린지 조회 API 응답 구조 변경 |<img width="1907" height="1095" alt="image" src="https://github.com/user-attachments/assets/300f5dc6-dd39-424f-abbf-f71fa25d2b5e" /> |

  # 😅 Uncompleted Tasks 😅
  - 없음

  # 📢 To Reviewers 📢
