### PR TITLE
[Feature] 메인 대시보드 구현

### DIFF
--- a/src/main/java/com/sopt/cherrish/domain/challenge/core/application/service/ChallengeService.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/core/application/service/ChallengeService.java
@@ -1,6 +1,7 @@
 package com.sopt.cherrish.domain.challenge.core.application.service;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -81,7 +82,7 @@ public class ChallengeService {
 	 * @param userId 사용자 ID
 	 * @return Optional로 감싼 활성 챌린지 (통계 포함)
 	 */
-	public java.util.Optional<Challenge> findActiveChallengeWithStatistics(Long userId) {
+	public Optional<Challenge> findActiveChallengeWithStatistics(Long userId) {
 		return challengeRepository.findActiveChallengeWithStatistics(userId);
 	}
 

--- a/src/main/java/com/sopt/cherrish/domain/challenge/core/application/service/ChallengeService.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/core/application/service/ChallengeService.java
@@ -76,6 +76,16 @@ public class ChallengeService {
 	}
 
 	/**
+	 * 활성 챌린지 조회 (통계와 함께 Fetch Join) - Optional 반환
+	 * 챌린지가 없어도 예외를 던지지 않음 (Facade에서 사용)
+	 * @param userId 사용자 ID
+	 * @return Optional로 감싼 활성 챌린지 (통계 포함)
+	 */
+	public java.util.Optional<Challenge> findActiveChallengeWithStatistics(Long userId) {
+		return challengeRepository.findActiveChallengeWithStatistics(userId);
+	}
+
+	/**
 	 * ID로 챌린지 조회
 	 * @param challengeId 챌린지 ID
 	 * @return 챌린지

--- a/src/main/java/com/sopt/cherrish/domain/maindashboard/application/facade/MainDashboardFacade.java
+++ b/src/main/java/com/sopt/cherrish/domain/maindashboard/application/facade/MainDashboardFacade.java
@@ -65,7 +65,7 @@ public class MainDashboardFacade {
 			log.info("사용자 {}의 활성 챌린지 없음 (cherryLevel=0)", userId);
 		}
 
-		// 4. 최근 시술 (가장 최근 날짜의 모든 시술, COMPLETED 제외)
+		// 4. 최근 시술 (다운타임 진행 중인 모든 시술, Phase/시간순 정렬)
 		List<UserProcedure> recentProcedureEntities =
 			userProcedureService.findRecentProcedures(userId, today);
 		List<RecentProcedureResponseDto> recentProcedures = recentProcedureEntities.stream()

--- a/src/main/java/com/sopt/cherrish/domain/maindashboard/application/facade/MainDashboardFacade.java
+++ b/src/main/java/com/sopt/cherrish/domain/maindashboard/application/facade/MainDashboardFacade.java
@@ -1,0 +1,77 @@
+package com.sopt.cherrish.domain.maindashboard.application.facade;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sopt.cherrish.domain.challenge.core.application.service.ChallengeService;
+import com.sopt.cherrish.domain.challenge.core.domain.model.Challenge;
+import com.sopt.cherrish.domain.challenge.core.domain.model.ChallengeStatistics;
+import com.sopt.cherrish.domain.maindashboard.presentation.dto.response.MainDashboardResponseDto;
+import com.sopt.cherrish.domain.maindashboard.presentation.dto.response.RecentProcedureResponseDto;
+import com.sopt.cherrish.domain.maindashboard.presentation.dto.response.UpcomingProcedureResponseDto;
+import com.sopt.cherrish.domain.user.application.service.UserService;
+import com.sopt.cherrish.domain.userprocedure.application.service.UserProcedureService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 메인 대시보드 Facade
+ * 여러 도메인(User, Challenge, UserProcedure)의 서비스를 조합하여 대시보드 데이터를 제공합니다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class MainDashboardFacade {
+
+	private final UserService userService;
+	private final ChallengeService challengeService;
+	private final UserProcedureService userProcedureService;
+	private final Clock clock;
+
+	/**
+	 * 메인 대시보드 조회
+	 * @param userId 사용자 ID
+	 * @return 메인 대시보드 응답
+	 */
+	public MainDashboardResponseDto getMainDashboard(Long userId) {
+		// 1. 사용자 존재 여부 확인
+		userService.validateUserExists(userId);
+
+		// 2. 오늘 날짜 가져오기
+		LocalDate today = LocalDate.now(clock);
+
+		// 3. 챌린지 데이터 (활성 챌린지 없으면 0)
+		Integer cherryLevel = 0;
+		Double challengeRate = 0.0;
+
+		var challengeOpt = challengeService.findActiveChallengeWithStatistics(userId);
+		if (challengeOpt.isPresent()) {
+			Challenge challenge = challengeOpt.get();
+			ChallengeStatistics stats = challenge.getStatistics();
+			cherryLevel = stats.calculateCherryLevel();
+			challengeRate = stats.getProgressPercentage();
+		} else {
+			log.info("사용자 {}의 활성 챌린지 없음 (cherryLevel=0)", userId);
+		}
+
+		// 4. 최근 시술 (가장 최근 날짜의 모든 시술, COMPLETED 제외)
+		List<RecentProcedureResponseDto> recentProcedures =
+			userProcedureService.findRecentProcedures(userId, today);
+
+		// 5. 다가오는 시술 (날짜별 그룹, 가장 가까운 3개 날짜)
+		List<UpcomingProcedureResponseDto> upcomingProcedures =
+			userProcedureService.findUpcomingProceduresGroupedByDate(userId, today, 3);
+
+		// 6. 응답 생성
+		return MainDashboardResponseDto.from(
+			today, cherryLevel, challengeRate,
+			recentProcedures, upcomingProcedures
+		);
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/maindashboard/application/facade/MainDashboardFacade.java
+++ b/src/main/java/com/sopt/cherrish/domain/maindashboard/application/facade/MainDashboardFacade.java
@@ -29,6 +29,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class MainDashboardFacade {
 
+    private static final int MAX_UPCOMING_PROCEDURE_DATES = 3;
+
 	private final UserService userService;
 	private final ChallengeService challengeService;
 	private final UserProcedureService userProcedureService;
@@ -66,7 +68,7 @@ public class MainDashboardFacade {
 
 		// 5. 다가오는 시술 (날짜별 그룹, 가장 가까운 3개 날짜)
 		List<UpcomingProcedureResponseDto> upcomingProcedures =
-			userProcedureService.findUpcomingProceduresGroupedByDate(userId, today, 3);
+			userProcedureService.findUpcomingProceduresGroupedByDate(userId, today, MAX_UPCOMING_PROCEDURE_DATES);
 
 		// 6. 응답 생성
 		return MainDashboardResponseDto.from(

--- a/src/main/java/com/sopt/cherrish/domain/maindashboard/domain/model/ProcedurePhase.java
+++ b/src/main/java/com/sopt/cherrish/domain/maindashboard/domain/model/ProcedurePhase.java
@@ -1,0 +1,35 @@
+package com.sopt.cherrish.domain.maindashboard.domain.model;
+
+import java.time.LocalDate;
+
+import com.sopt.cherrish.domain.userprocedure.domain.vo.DowntimePeriod;
+
+/**
+ * 시술 후 회복 단계
+ */
+public enum ProcedurePhase {
+	SENSITIVE,   // 민감기
+	CAUTION,     // 주의기
+	RECOVERY,    // 회복기
+	COMPLETED;   // 완료 (다운타임 종료)
+
+	/**
+	 * 다운타임 기간과 현재 날짜를 기반으로 현재 단계 계산
+	 *
+	 * @param downtimePeriod 다운타임 기간
+	 * @param today 현재 날짜
+	 * @return 현재 시술 단계
+	 */
+	public static ProcedurePhase calculate(DowntimePeriod downtimePeriod, LocalDate today) {
+		if (downtimePeriod.getSensitiveDays().contains(today)) {
+			return SENSITIVE;
+		}
+		if (downtimePeriod.getCautionDays().contains(today)) {
+			return CAUTION;
+		}
+		if (downtimePeriod.getRecoveryDays().contains(today)) {
+			return RECOVERY;
+		}
+		return COMPLETED;
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/MainDashboardController.java
+++ b/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/MainDashboardController.java
@@ -1,0 +1,42 @@
+package com.sopt.cherrish.domain.maindashboard.presentation;
+
+import com.sopt.cherrish.global.annotation.ApiExceptions;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sopt.cherrish.domain.maindashboard.application.facade.MainDashboardFacade;
+import com.sopt.cherrish.domain.maindashboard.presentation.dto.response.MainDashboardResponseDto;
+import com.sopt.cherrish.global.response.CommonApiResponse;
+import com.sopt.cherrish.global.response.error.ErrorCode;
+import com.sopt.cherrish.global.response.success.SuccessCode;
+import com.sopt.cherrish.domain.user.exception.UserErrorCode;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/main-dashboard")
+@RequiredArgsConstructor
+@Tag(name = "Main Dashboard", description = "메인 대시보드 API")
+public class MainDashboardController {
+
+	private final MainDashboardFacade mainDashboardFacade;
+
+	@Operation(
+		summary = "메인 대시보드 조회",
+		description = "사용자의 챌린지 진행률, 최근 시술, 예정된 시술 정보를 조회합니다."
+	)
+	@ApiExceptions({UserErrorCode.class, ErrorCode.class})
+	@GetMapping
+	public CommonApiResponse<MainDashboardResponseDto> getMainDashboard(
+		@Parameter(description = "사용자 ID", required = true, example = "1")
+		@RequestHeader("X-User-Id") Long userId
+	) {
+		MainDashboardResponseDto response = mainDashboardFacade.getMainDashboard(userId);
+		return CommonApiResponse.success(SuccessCode.SUCCESS, response);
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/dto/response/MainDashboardResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/dto/response/MainDashboardResponseDto.java
@@ -24,7 +24,7 @@ public class MainDashboardResponseDto {
 	@Schema(description = "챌린지 완료율 (%)", example = "40.3")
 	private Double challengeRate;
 
-	@Schema(description = "최근 시술 목록 (가장 최근 날짜의 모든 시술, 다운타임 완료 시 null)")
+	@Schema(description = "최근 시술 목록 (가장 최근 날짜의 다운타임 진행 중인 시술, 없으면 빈 배열)")
 	private List<RecentProcedureResponseDto> recentProcedures;
 
 	@Schema(description = "예정된 시술 목록 (날짜별 그룹, 최대 3개 날짜)")

--- a/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/dto/response/MainDashboardResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/dto/response/MainDashboardResponseDto.java
@@ -24,7 +24,7 @@ public class MainDashboardResponseDto {
 	@Schema(description = "챌린지 완료율 (%)", example = "40.3")
 	private Double challengeRate;
 
-	@Schema(description = "최근 시술 목록 (가장 최근 날짜의 다운타임 진행 중인 시술, 없으면 빈 배열)")
+	@Schema(description = "최근 시술 목록 (다운타임 진행 중)")
 	private List<RecentProcedureResponseDto> recentProcedures;
 
 	@Schema(description = "예정된 시술 목록 (날짜별 그룹, 최대 3개 날짜)")

--- a/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/dto/response/MainDashboardResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/dto/response/MainDashboardResponseDto.java
@@ -1,0 +1,48 @@
+package com.sopt.cherrish.domain.maindashboard.presentation.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "메인 대시보드 응답")
+public class MainDashboardResponseDto {
+
+	@Schema(description = "오늘 날짜", example = "2026-01-15")
+	@JsonFormat(pattern = "yyyy-MM-dd")
+	private LocalDate date;
+
+	@Schema(description = "체리 레벨 (0-4, 챌린지 없으면 0)", example = "2")
+	private Integer cherryLevel;
+
+	@Schema(description = "챌린지 완료율 (%)", example = "40.3")
+	private Double challengeRate;
+
+	@Schema(description = "최근 시술 목록 (가장 최근 날짜의 모든 시술, 다운타임 완료 시 null)")
+	private List<RecentProcedureResponseDto> recentProcedures;
+
+	@Schema(description = "예정된 시술 목록 (날짜별 그룹, 최대 3개 날짜)")
+	private List<UpcomingProcedureResponseDto> upcomingProcedures;
+
+	public static MainDashboardResponseDto from(
+		LocalDate today,
+		Integer cherryLevel,
+		Double challengeRate,
+		List<RecentProcedureResponseDto> recentProcedures,
+		List<UpcomingProcedureResponseDto> upcomingProcedures
+	) {
+		return MainDashboardResponseDto.builder()
+			.date(today)
+			.cherryLevel(cherryLevel)
+			.challengeRate(challengeRate)
+			.recentProcedures(recentProcedures)
+			.upcomingProcedures(upcomingProcedures)
+			.build();
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/dto/response/MainDashboardResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/dto/response/MainDashboardResponseDto.java
@@ -18,7 +18,7 @@ public class MainDashboardResponseDto {
 	@JsonFormat(pattern = "yyyy-MM-dd")
 	private LocalDate date;
 
-	@Schema(description = "체리 레벨 (0-4, 챌린지 없으면 0)", example = "2")
+	@Schema(description = "체리 레벨 (1-4, 챌린지 없으면 0)", example = "2")
 	private Integer cherryLevel;
 
 	@Schema(description = "챌린지 완료율 (%)", example = "40.3")

--- a/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/dto/response/RecentProcedureResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/dto/response/RecentProcedureResponseDto.java
@@ -17,7 +17,7 @@ public class RecentProcedureResponseDto {
 	@Schema(description = "시술명", example = "레이저 토닝")
 	private String name;
 
-	@Schema(description = "시술 후 경과 일수", example = "3")
+	@Schema(description = "회복 N일차 (시술 당일 = 1일차)", example = "3")
 	private Integer daysSince;
 
 	@Schema(description = "현재 단계", example = "SENSITIVE")
@@ -35,7 +35,7 @@ public class RecentProcedureResponseDto {
 
 		return RecentProcedureResponseDto.builder()
 			.name(userProcedure.getProcedure().getName())
-			.daysSince(daysSince)
+			.daysSince(daysSince + 1)  // 회복 N일차 (시술 당일 = 1일차)
 			.currentPhase(phase)
 			.build();
 	}

--- a/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/dto/response/RecentProcedureResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/dto/response/RecentProcedureResponseDto.java
@@ -1,0 +1,42 @@
+package com.sopt.cherrish.domain.maindashboard.presentation.dto.response;
+
+import java.time.temporal.ChronoUnit;
+
+import com.sopt.cherrish.domain.maindashboard.domain.model.ProcedurePhase;
+import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "최근 시술 정보")
+public class RecentProcedureResponseDto {
+
+	@Schema(description = "시술명", example = "레이저 토닝")
+	private String name;
+
+	@Schema(description = "시술 후 경과 일수", example = "3")
+	private Integer daysSince;
+
+	@Schema(description = "현재 단계", example = "SENSITIVE")
+	private ProcedurePhase currentPhase;
+
+	public static RecentProcedureResponseDto from(
+		UserProcedure userProcedure,
+		java.time.LocalDate today,
+		ProcedurePhase phase
+	) {
+		int daysSince = (int) ChronoUnit.DAYS.between(
+			userProcedure.getScheduledAt().toLocalDate(),
+			today
+		);
+
+		return RecentProcedureResponseDto.builder()
+			.name(userProcedure.getProcedure().getName())
+			.daysSince(daysSince)
+			.currentPhase(phase)
+			.build();
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/dto/response/RecentProcedureResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/dto/response/RecentProcedureResponseDto.java
@@ -2,7 +2,7 @@ package com.sopt.cherrish.domain.maindashboard.presentation.dto.response;
 
 import java.time.temporal.ChronoUnit;
 
-import com.sopt.cherrish.domain.maindashboard.domain.model.ProcedurePhase;
+import com.sopt.cherrish.domain.userprocedure.domain.model.ProcedurePhase;
 import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
 
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/dto/response/RecentProcedureResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/dto/response/RecentProcedureResponseDto.java
@@ -1,5 +1,6 @@
 package com.sopt.cherrish.domain.maindashboard.presentation.dto.response;
 
+import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 
 import com.sopt.cherrish.domain.userprocedure.domain.model.ProcedurePhase;
@@ -25,7 +26,7 @@ public class RecentProcedureResponseDto {
 
 	public static RecentProcedureResponseDto from(
 		UserProcedure userProcedure,
-		java.time.LocalDate today,
+		LocalDate today,
 		ProcedurePhase phase
 	) {
 		int daysSince = (int) ChronoUnit.DAYS.between(

--- a/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/dto/response/UpcomingProcedureResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/dto/response/UpcomingProcedureResponseDto.java
@@ -1,0 +1,45 @@
+package com.sopt.cherrish.domain.maindashboard.presentation.dto.response;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "날짜별 예정 시술 정보")
+public class UpcomingProcedureResponseDto {
+
+	@Schema(description = "시술 날짜", example = "2026-01-20")
+	@JsonFormat(pattern = "yyyy-MM-dd")
+	private LocalDate date;
+
+	@Schema(description = "해당 날짜의 대표 시술명 (다운타임 가장 긴 것)", example = "보톡스")
+	private String name;
+
+	@Schema(description = "해당 날짜의 총 시술 개수", example = "2")
+	private Integer count;
+
+	@Schema(description = "D-Day (시술까지 남은 일수)", example = "5")
+	private Integer dDay;
+
+	public static UpcomingProcedureResponseDto of(
+		LocalDate date,
+		String name,
+		Integer count,
+		LocalDate today
+	) {
+		int dDay = (int) ChronoUnit.DAYS.between(today, date);
+
+		return UpcomingProcedureResponseDto.builder()
+			.date(date)
+			.name(name)
+			.count(count)
+			.dDay(dDay)
+			.build();
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/application/service/UserProcedureService.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/application/service/UserProcedureService.java
@@ -76,15 +76,16 @@ public class UserProcedureService {
 	}
 
 	/**
-	 * 최근 시술 조회 (가장 최근 날짜의 모든 시술, COMPLETED 제외, 정렬됨)
-	 * 정렬 순서: 1) ProcedurePhase (SENSITIVE > CAUTION > RECOVERY) 2) 최근 시술부터
+	 * 다운타임 진행 중인 모든 시술 조회 (COMPLETED 제외, 정렬됨)
+	 * 정렬 순서: 1) ProcedurePhase (SENSITIVE > CAUTION > RECOVERY) 2) 같은 Phase면 최근 시술부터
 	 * @param userId 사용자 ID
 	 * @param today 오늘 날짜
 	 * @return 정렬된 시술 엔티티 리스트
 	 */
 	public List<UserProcedure> findRecentProcedures(Long userId, LocalDate today) {
+		// 오늘까지의 모든 과거 시술 조회
 		return userProcedureRepository
-			.findProceduresOnMostRecentDate(userId, today)
+			.findAllPastProcedures(userId, today)
 			.stream()
 			.filter(up -> up.calculateCurrentPhase(today) != ProcedurePhase.COMPLETED)
 			.sorted(Comparator

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/application/service/UserProcedureService.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/application/service/UserProcedureService.java
@@ -111,18 +111,17 @@ public class UserProcedureService {
 			.findUpcomingProceduresGroupedByDate(userId, tomorrow);
 
 		// 날짜별로 그룹핑 후 가장 가까운 N개 날짜만 선택
-		return allUpcoming.stream()
+		Map<LocalDate, List<UserProcedure>> grouped = allUpcoming.stream()
 			.collect(Collectors.groupingBy(
 				up -> up.getScheduledAt().toLocalDate()
-			))
-			.entrySet().stream()
+			));
+
+		Map<LocalDate, List<UserProcedure>> limited = new java.util.LinkedHashMap<>();
+		grouped.entrySet().stream()
 			.sorted(Map.Entry.comparingByKey()) // 날짜 오름차순
 			.limit(limitDates) // 최대 N개 날짜
-			.collect(Collectors.toMap(
-				Map.Entry::getKey,
-				Map.Entry::getValue,
-				(e1, e2) -> e1,
-				java.util.LinkedHashMap::new // 순서 유지
-			));
+			.forEach(entry -> limited.put(entry.getKey(), entry.getValue()));
+
+		return limited;
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/application/service/UserProcedureService.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/application/service/UserProcedureService.java
@@ -5,27 +5,23 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
-import com.sopt.cherrish.domain.user.domain.model.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
 import com.sopt.cherrish.domain.procedure.domain.repository.ProcedureRepository;
 import com.sopt.cherrish.domain.procedure.exception.ProcedureErrorCode;
 import com.sopt.cherrish.domain.procedure.exception.ProcedureException;
+import com.sopt.cherrish.domain.user.domain.model.User;
 import com.sopt.cherrish.domain.user.domain.repository.UserRepository;
 import com.sopt.cherrish.domain.user.exception.UserErrorCode;
 import com.sopt.cherrish.domain.user.exception.UserException;
-import com.sopt.cherrish.domain.maindashboard.domain.model.ProcedurePhase;
-import com.sopt.cherrish.domain.maindashboard.presentation.dto.response.RecentProcedureResponseDto;
-import com.sopt.cherrish.domain.maindashboard.presentation.dto.response.UpcomingProcedureResponseDto;
+import com.sopt.cherrish.domain.userprocedure.domain.model.ProcedurePhase;
 import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
 import com.sopt.cherrish.domain.userprocedure.domain.repository.UserProcedureRepository;
-import com.sopt.cherrish.domain.userprocedure.domain.vo.DowntimePeriod;
 import com.sopt.cherrish.domain.userprocedure.presentation.dto.request.UserProcedureCreateRequestDto;
 import com.sopt.cherrish.domain.userprocedure.presentation.dto.request.UserProcedureCreateRequestItemDto;
 import com.sopt.cherrish.domain.userprocedure.presentation.dto.response.UserProcedureCreateResponseDto;
@@ -80,44 +76,22 @@ public class UserProcedureService {
 	}
 
 	/**
-	 * 최근 시술 조회 (가장 최근 날짜의 모든 시술, COMPLETED 제외)
+	 * 최근 시술 조회 (가장 최근 날짜의 모든 시술, COMPLETED 제외, 정렬됨)
 	 * 정렬 순서: 1) ProcedurePhase (SENSITIVE > CAUTION > RECOVERY) 2) 최근 시술부터
 	 * @param userId 사용자 ID
 	 * @param today 오늘 날짜
-	 * @return 최근 시술 DTO 리스트
+	 * @return 정렬된 시술 엔티티 리스트
 	 */
-	public List<RecentProcedureResponseDto> findRecentProcedures(Long userId, LocalDate today) {
+	public List<UserProcedure> findRecentProcedures(Long userId, LocalDate today) {
 		return userProcedureRepository
 			.findProceduresOnMostRecentDate(userId, today)
 			.stream()
-			.map(up -> {
-				ProcedurePhase phase = calculatePhase(up, today);
-				if (phase == ProcedurePhase.COMPLETED) {
-					return null;
-				}
-				return new RecentProcedureWithPhase(
-					RecentProcedureResponseDto.from(up, today, phase),
-					phase,
-					up.getScheduledAt()
-				);
-			})
-			.filter(Objects::nonNull)
+			.filter(up -> up.calculateCurrentPhase(today) != ProcedurePhase.COMPLETED)
 			.sorted(Comparator
-				.comparing((RecentProcedureWithPhase r) -> r.phase) // 민감기 > 주의기 > 회복기
-				.thenComparing(r -> r.scheduledAt, Comparator.reverseOrder()) // 최근 시술부터
+				.comparing((UserProcedure up) -> up.calculateCurrentPhase(today))
+				.thenComparing(UserProcedure::getScheduledAt, Comparator.reverseOrder())
 			)
-			.map(r -> r.dto)
 			.toList();
-	}
-
-	/**
-	 * 정렬을 위한 내부 클래스
-	 */
-	private record RecentProcedureWithPhase(
-		RecentProcedureResponseDto dto,
-		ProcedurePhase phase,
-		java.time.LocalDateTime scheduledAt
-	) {
 	}
 
 	/**
@@ -125,9 +99,9 @@ public class UserProcedureService {
 	 * @param userId 사용자 ID
 	 * @param today 오늘 날짜
 	 * @param limitDates 조회할 최대 날짜 개수
-	 * @return 날짜별 예정 시술 DTO 리스트
+	 * @return 날짜별로 그룹핑된 시술 Map (날짜 오름차순)
 	 */
-	public List<UpcomingProcedureResponseDto> findUpcomingProceduresGroupedByDate(
+	public Map<LocalDate, List<UserProcedure>> findUpcomingProceduresGroupedByDate(
 		Long userId, LocalDate today, int limitDates
 	) {
 		LocalDate tomorrow = today.plusDays(1);
@@ -136,43 +110,19 @@ public class UserProcedureService {
 		List<UserProcedure> allUpcoming = userProcedureRepository
 			.findUpcomingProceduresGroupedByDate(userId, tomorrow);
 
-		// 날짜별로 그룹핑
-		Map<LocalDate, List<UserProcedure>> groupedByDate = allUpcoming.stream()
+		// 날짜별로 그룹핑 후 가장 가까운 N개 날짜만 선택
+		return allUpcoming.stream()
 			.collect(Collectors.groupingBy(
 				up -> up.getScheduledAt().toLocalDate()
-			));
-
-		// 가장 가까운 N개 날짜만 선택, 각 날짜마다 다운타임 가장 긴 시술 찾기
-		return groupedByDate.entrySet().stream()
+			))
+			.entrySet().stream()
 			.sorted(Map.Entry.comparingByKey()) // 날짜 오름차순
 			.limit(limitDates) // 최대 N개 날짜
-			.map(entry -> {
-				LocalDate date = entry.getKey();
-				List<UserProcedure> procedures = entry.getValue();
-
-				// 다운타임 가장 긴 시술 찾기
-				UserProcedure longest = procedures.stream()
-					.max(Comparator.comparing(UserProcedure::getDowntimeDays))
-					.orElseThrow();
-
-				return UpcomingProcedureResponseDto.of(
-					date,
-					longest.getProcedure().getName(),
-					procedures.size(),
-					today
-				);
-			})
-			.toList();
-	}
-
-	/**
-	 * UserProcedure의 현재 다운타임 단계 계산
-	 * @param userProcedure 사용자 시술
-	 * @param today 오늘 날짜
-	 * @return 다운타임 단계
-	 */
-	private ProcedurePhase calculatePhase(UserProcedure userProcedure, LocalDate today) {
-		DowntimePeriod period = userProcedure.calculateDowntimePeriod();
-		return ProcedurePhase.calculate(period, today);
+			.collect(Collectors.toMap(
+				Map.Entry::getKey,
+				Map.Entry::getValue,
+				(e1, e2) -> e1,
+				java.util.LinkedHashMap::new // 순서 유지
+			));
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/application/service/UserProcedureService.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/application/service/UserProcedureService.java
@@ -3,6 +3,7 @@ package com.sopt.cherrish.domain.userprocedure.application.service;
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -117,12 +118,15 @@ public class UserProcedureService {
 				up -> up.getScheduledAt().toLocalDate()
 			));
 
-		Map<LocalDate, List<UserProcedure>> limited = new java.util.LinkedHashMap<>();
-		grouped.entrySet().stream()
-			.sorted(Map.Entry.comparingByKey()) // 날짜 오름차순
-			.limit(limitDates) // 최대 N개 날짜
-			.forEach(entry -> limited.put(entry.getKey(), entry.getValue()));
+		return grouped.entrySet().stream()
+			.sorted(Map.Entry.comparingByKey()) // 날짜 오름차순 정렬
+			.limit(limitDates)
+			.collect(Collectors.toMap(
+				Map.Entry::getKey,
+				Map.Entry::getValue,
+				(e1, e2) -> e1,
+				LinkedHashMap::new
+			));
 
-		return limited;
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/application/service/UserProcedureService.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/application/service/UserProcedureService.java
@@ -1,7 +1,11 @@
 package com.sopt.cherrish.domain.userprocedure.application.service;
 
+import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -16,8 +20,12 @@ import com.sopt.cherrish.domain.procedure.exception.ProcedureException;
 import com.sopt.cherrish.domain.user.domain.repository.UserRepository;
 import com.sopt.cherrish.domain.user.exception.UserErrorCode;
 import com.sopt.cherrish.domain.user.exception.UserException;
+import com.sopt.cherrish.domain.maindashboard.domain.model.ProcedurePhase;
+import com.sopt.cherrish.domain.maindashboard.presentation.dto.response.RecentProcedureResponseDto;
+import com.sopt.cherrish.domain.maindashboard.presentation.dto.response.UpcomingProcedureResponseDto;
 import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
 import com.sopt.cherrish.domain.userprocedure.domain.repository.UserProcedureRepository;
+import com.sopt.cherrish.domain.userprocedure.domain.vo.DowntimePeriod;
 import com.sopt.cherrish.domain.userprocedure.presentation.dto.request.UserProcedureCreateRequestDto;
 import com.sopt.cherrish.domain.userprocedure.presentation.dto.request.UserProcedureCreateRequestItemDto;
 import com.sopt.cherrish.domain.userprocedure.presentation.dto.response.UserProcedureCreateResponseDto;
@@ -69,5 +77,102 @@ public class UserProcedureService {
 		}
 
 		return procedures;
+	}
+
+	/**
+	 * 최근 시술 조회 (가장 최근 날짜의 모든 시술, COMPLETED 제외)
+	 * 정렬 순서: 1) ProcedurePhase (SENSITIVE > CAUTION > RECOVERY) 2) 최근 시술부터
+	 * @param userId 사용자 ID
+	 * @param today 오늘 날짜
+	 * @return 최근 시술 DTO 리스트
+	 */
+	public List<RecentProcedureResponseDto> findRecentProcedures(Long userId, LocalDate today) {
+		return userProcedureRepository
+			.findProceduresOnMostRecentDate(userId, today)
+			.stream()
+			.map(up -> {
+				ProcedurePhase phase = calculatePhase(up, today);
+				if (phase == ProcedurePhase.COMPLETED) {
+					return null;
+				}
+				return new RecentProcedureWithPhase(
+					RecentProcedureResponseDto.from(up, today, phase),
+					phase,
+					up.getScheduledAt()
+				);
+			})
+			.filter(Objects::nonNull)
+			.sorted(Comparator
+				.comparing((RecentProcedureWithPhase r) -> r.phase) // 민감기 > 주의기 > 회복기
+				.thenComparing(r -> r.scheduledAt, Comparator.reverseOrder()) // 최근 시술부터
+			)
+			.map(r -> r.dto)
+			.toList();
+	}
+
+	/**
+	 * 정렬을 위한 내부 클래스
+	 */
+	private record RecentProcedureWithPhase(
+		RecentProcedureResponseDto dto,
+		ProcedurePhase phase,
+		java.time.LocalDateTime scheduledAt
+	) {
+	}
+
+	/**
+	 * 다가오는 시술 조회 (날짜별 그룹핑, 가장 가까운 N개 날짜)
+	 * @param userId 사용자 ID
+	 * @param today 오늘 날짜
+	 * @param limitDates 조회할 최대 날짜 개수
+	 * @return 날짜별 예정 시술 DTO 리스트
+	 */
+	public List<UpcomingProcedureResponseDto> findUpcomingProceduresGroupedByDate(
+		Long userId, LocalDate today, int limitDates
+	) {
+		LocalDate tomorrow = today.plusDays(1);
+
+		// 내일부터 시작하는 모든 미래 시술 조회
+		List<UserProcedure> allUpcoming = userProcedureRepository
+			.findUpcomingProceduresGroupedByDate(userId, tomorrow);
+
+		// 날짜별로 그룹핑
+		Map<LocalDate, List<UserProcedure>> groupedByDate = allUpcoming.stream()
+			.collect(Collectors.groupingBy(
+				up -> up.getScheduledAt().toLocalDate()
+			));
+
+		// 가장 가까운 N개 날짜만 선택, 각 날짜마다 다운타임 가장 긴 시술 찾기
+		return groupedByDate.entrySet().stream()
+			.sorted(Map.Entry.comparingByKey()) // 날짜 오름차순
+			.limit(limitDates) // 최대 N개 날짜
+			.map(entry -> {
+				LocalDate date = entry.getKey();
+				List<UserProcedure> procedures = entry.getValue();
+
+				// 다운타임 가장 긴 시술 찾기
+				UserProcedure longest = procedures.stream()
+					.max(Comparator.comparing(UserProcedure::getDowntimeDays))
+					.orElseThrow();
+
+				return UpcomingProcedureResponseDto.of(
+					date,
+					longest.getProcedure().getName(),
+					procedures.size(),
+					today
+				);
+			})
+			.toList();
+	}
+
+	/**
+	 * UserProcedure의 현재 다운타임 단계 계산
+	 * @param userProcedure 사용자 시술
+	 * @param today 오늘 날짜
+	 * @return 다운타임 단계
+	 */
+	private ProcedurePhase calculatePhase(UserProcedure userProcedure, LocalDate today) {
+		DowntimePeriod period = userProcedure.calculateDowntimePeriod();
+		return ProcedurePhase.calculate(period, today);
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/model/ProcedurePhase.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/model/ProcedurePhase.java
@@ -1,4 +1,4 @@
-package com.sopt.cherrish.domain.maindashboard.domain.model;
+package com.sopt.cherrish.domain.userprocedure.domain.model;
 
 import java.time.LocalDate;
 

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/model/UserProcedure.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/model/UserProcedure.java
@@ -62,4 +62,15 @@ public class UserProcedure extends BaseTimeEntity {
 	public DowntimePeriod calculateDowntimePeriod() {
 		return DowntimePeriod.calculate(this.downtimeDays, this.scheduledAt.toLocalDate());
 	}
+
+	/**
+	 * 현재 날짜 기준 시술 후 회복 단계 계산
+	 *
+	 * @param today 현재 날짜
+	 * @return 현재 시술 단계 (SENSITIVE, CAUTION, RECOVERY, COMPLETED)
+	 */
+	public ProcedurePhase calculateCurrentPhase(java.time.LocalDate today) {
+		DowntimePeriod period = calculateDowntimePeriod();
+		return ProcedurePhase.calculate(period, today);
+	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/model/UserProcedure.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/model/UserProcedure.java
@@ -1,5 +1,6 @@
 package com.sopt.cherrish.domain.userprocedure.domain.model;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
@@ -69,7 +70,7 @@ public class UserProcedure extends BaseTimeEntity {
 	 * @param today 현재 날짜
 	 * @return 현재 시술 단계 (SENSITIVE, CAUTION, RECOVERY, COMPLETED)
 	 */
-	public ProcedurePhase calculateCurrentPhase(java.time.LocalDate today) {
+	public ProcedurePhase calculateCurrentPhase(LocalDate today) {
 		DowntimePeriod period = calculateDowntimePeriod();
 		return ProcedurePhase.calculate(period, today);
 	}

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryCustom.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryCustom.java
@@ -26,12 +26,12 @@ public interface UserProcedureRepositoryCustom {
 	List<UserProcedure> findDailyProcedures(Long userId, LocalDate date);
 
 	/**
-	 * 가장 최근 날짜(당일 포함)에 받은 모든 시술 조회
+	 * 특정 날짜 이전(당일 포함)의 모든 과거 시술 조회
 	 * @param userId 사용자 ID
-	 * @param date 기준 날짜 (당일 포함)
-	 * @return 가장 최근 날짜의 모든 시술 목록
+	 * @param beforeDate 기준 날짜 (이 날짜 이전 시술 조회, 당일 포함)
+	 * @return 과거 시술 목록
 	 */
-	List<UserProcedure> findProceduresOnMostRecentDate(Long userId, LocalDate date);
+	List<UserProcedure> findAllPastProcedures(Long userId, LocalDate beforeDate);
 
 	/**
 	 * 특정 날짜 이후의 모든 미래 시술 조회 (날짜별 그룹핑용)

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryCustom.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryCustom.java
@@ -24,4 +24,20 @@ public interface UserProcedureRepositoryCustom {
 	 * @return 시술 목록
 	 */
 	List<UserProcedure> findDailyProcedures(Long userId, LocalDate date);
+
+	/**
+	 * 가장 최근 날짜(당일 포함)에 받은 모든 시술 조회
+	 * @param userId 사용자 ID
+	 * @param date 기준 날짜 (당일 포함)
+	 * @return 가장 최근 날짜의 모든 시술 목록
+	 */
+	List<UserProcedure> findProceduresOnMostRecentDate(Long userId, LocalDate date);
+
+	/**
+	 * 특정 날짜 이후의 모든 미래 시술 조회 (날짜별 그룹핑용)
+	 * @param userId 사용자 ID
+	 * @param fromDate 시작 날짜 (내일부터)
+	 * @return 미래 시술 목록 (날짜 오름차순, 다운타임 내림차순)
+	 */
+	List<UserProcedure> findUpcomingProceduresGroupedByDate(Long userId, LocalDate fromDate);
 }

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryCustom.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryCustom.java
@@ -26,12 +26,13 @@ public interface UserProcedureRepositoryCustom {
 	List<UserProcedure> findDailyProcedures(Long userId, LocalDate date);
 
 	/**
-	 * 특정 날짜 이전(당일 포함)의 모든 과거 시술 조회
+	 * 특정 기간 내의 과거 시술 조회
 	 * @param userId 사용자 ID
-	 * @param beforeDate 기준 날짜 (이 날짜 이전 시술 조회, 당일 포함)
+	 * @param fromDate 시작 날짜 (이 날짜 이후 시술 조회, 당일 포함)
+	 * @param toDate 기준 날짜 (이 날짜 이전 시술 조회, 당일 포함)
 	 * @return 과거 시술 목록
 	 */
-	List<UserProcedure> findAllPastProcedures(Long userId, LocalDate beforeDate);
+	List<UserProcedure> findAllPastProcedures(Long userId, LocalDate fromDate, LocalDate toDate);
 
 	/**
 	 * 특정 날짜 이후의 모든 미래 시술 조회 (날짜별 그룹핑용)

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryImpl.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryImpl.java
@@ -63,14 +63,16 @@ public class UserProcedureRepositoryImpl implements UserProcedureRepositoryCusto
 	}
 
 	@Override
-	public List<UserProcedure> findAllPastProcedures(Long userId, LocalDate beforeDate) {
-		LocalDateTime endOfDay = beforeDate.plusDays(1).atStartOfDay();
+	public List<UserProcedure> findAllPastProcedures(Long userId, LocalDate fromDate, LocalDate toDate) {
+		LocalDateTime startOfDay = fromDate.atStartOfDay();
+		LocalDateTime endOfDay = toDate.plusDays(1).atStartOfDay();
 
 		return queryFactory
 			.selectFrom(userProcedure)
 			.join(userProcedure.procedure).fetchJoin()  // N+1 방지
 			.where(
 				userProcedure.user.id.eq(userId),
+				userProcedure.scheduledAt.goe(startOfDay),
 				userProcedure.scheduledAt.lt(endOfDay)
 			)
 			.orderBy(userProcedure.scheduledAt.desc())

--- a/src/test/java/com/sopt/cherrish/domain/maindashboard/application/facade/MainDashboardFacadeTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/maindashboard/application/facade/MainDashboardFacadeTest.java
@@ -1,0 +1,274 @@
+package com.sopt.cherrish.domain.maindashboard.application.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sopt.cherrish.domain.challenge.core.application.service.ChallengeService;
+import com.sopt.cherrish.domain.challenge.core.domain.model.Challenge;
+import com.sopt.cherrish.domain.challenge.core.domain.model.ChallengeStatistics;
+import com.sopt.cherrish.domain.maindashboard.presentation.dto.response.MainDashboardResponseDto;
+import com.sopt.cherrish.domain.maindashboard.presentation.dto.response.RecentProcedureResponseDto;
+import com.sopt.cherrish.domain.maindashboard.presentation.dto.response.UpcomingProcedureResponseDto;
+import com.sopt.cherrish.domain.procedure.fixture.ProcedureFixture;
+import com.sopt.cherrish.domain.user.application.service.UserService;
+import com.sopt.cherrish.domain.user.fixture.UserFixture;
+import com.sopt.cherrish.domain.userprocedure.application.service.UserProcedureService;
+import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
+import com.sopt.cherrish.domain.userprocedure.fixture.UserProcedureFixture;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MainDashboardFacade 단위 테스트")
+class MainDashboardFacadeTest {
+
+	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+	private MainDashboardFacade mainDashboardFacade;
+
+	@Mock
+	private UserService userService;
+
+	@Mock
+	private ChallengeService challengeService;
+
+	@Mock
+	private UserProcedureService userProcedureService;
+
+	private LocalDate today;
+
+	@BeforeEach
+	void setUp() {
+		today = LocalDate.of(2026, 1, 15);
+		Clock fixedClock = Clock.fixed(Instant.parse("2026-01-15T00:00:00Z"), KST);
+		mainDashboardFacade = new MainDashboardFacade(
+			userService, challengeService, userProcedureService, fixedClock
+		);
+	}
+
+	@Test
+	@DisplayName("활성 챌린지/최근 시술이 없으면 기본값과 빈 리스트 반환")
+	void getMainDashboardDefaults() {
+		// given
+		Long userId = 1L;
+		given(challengeService.findActiveChallengeWithStatistics(userId))
+			.willReturn(Optional.empty());
+		given(userProcedureService.findRecentProcedures(userId, today))
+			.willReturn(List.of());
+		given(userProcedureService.findUpcomingProceduresGroupedByDate(userId, today, 3))
+			.willReturn(Map.of());
+
+		// when
+		MainDashboardResponseDto result = mainDashboardFacade.getMainDashboard(userId);
+
+		// then
+		assertThat(result.getCherryLevel()).isEqualTo(0);
+		assertThat(result.getChallengeRate()).isEqualTo(0.0);
+		assertThat(result.getRecentProcedures()).isEmpty();
+		assertThat(result.getUpcomingProcedures()).isEmpty();
+	}
+
+	@Test
+	@DisplayName("활성 챌린지가 없으면 체리 레벨 0으로 반환")
+	void getMainDashboardWithoutActiveChallenge() {
+		// given
+		Long userId = 2L;
+		given(challengeService.findActiveChallengeWithStatistics(userId))
+			.willReturn(Optional.empty());
+
+		var user = UserFixture.createUser();
+		UserProcedure recent = UserProcedureFixture.createUserProcedure(
+			user,
+			ProcedureFixture.createProcedure("레이저", "레이저", 0, 5),
+			LocalDateTime.of(2026, 1, 14, 10, 0),
+			6
+		);
+		given(userProcedureService.findRecentProcedures(userId, today))
+			.willReturn(List.of(recent));
+		given(userProcedureService.findUpcomingProceduresGroupedByDate(userId, today, 3))
+			.willReturn(Map.of());
+
+		// when
+		MainDashboardResponseDto result = mainDashboardFacade.getMainDashboard(userId);
+
+		// then
+		assertThat(result.getCherryLevel()).isEqualTo(0);
+		assertThat(result.getChallengeRate()).isEqualTo(0.0);
+		assertThat(result.getRecentProcedures()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("다운타임 중인 시술이 없으면 recentProcedures는 빈 리스트")
+	void getMainDashboardWithoutRecentProcedures() {
+		// given
+		Long userId = 3L;
+		Challenge challenge = org.mockito.Mockito.mock(Challenge.class);
+		ChallengeStatistics stats = org.mockito.Mockito.mock(ChallengeStatistics.class);
+		given(challengeService.findActiveChallengeWithStatistics(userId))
+			.willReturn(Optional.of(challenge));
+		given(challenge.getStatistics()).willReturn(stats);
+		given(stats.calculateCherryLevel()).willReturn(2);
+		given(stats.getProgressPercentage()).willReturn(40.0);
+
+		given(userProcedureService.findRecentProcedures(userId, today))
+			.willReturn(List.of());
+
+		var user = UserFixture.createUser();
+		Map<LocalDate, List<UserProcedure>> upcoming = new LinkedHashMap<>();
+		upcoming.put(
+			LocalDate.of(2026, 1, 16),
+			List.of(
+				UserProcedureFixture.createUserProcedure(
+					user,
+					ProcedureFixture.createProcedure("보톡스", "주사", 0, 5),
+					LocalDateTime.of(2026, 1, 16, 9, 0),
+					2
+				)
+			)
+		);
+		given(userProcedureService.findUpcomingProceduresGroupedByDate(userId, today, 3))
+			.willReturn(upcoming);
+
+		// when
+		MainDashboardResponseDto result = mainDashboardFacade.getMainDashboard(userId);
+
+		// then
+		assertThat(result.getRecentProcedures()).isEmpty();
+		assertThat(result.getUpcomingProcedures()).hasSize(1);
+	}
+
+	@Test
+	@DisplayName("다가오는 시술이 없으면 upcomingProcedures는 빈 리스트")
+	void getMainDashboardWithoutUpcomingProcedures() {
+		// given
+		Long userId = 4L;
+		Challenge challenge = org.mockito.Mockito.mock(Challenge.class);
+		ChallengeStatistics stats = org.mockito.Mockito.mock(ChallengeStatistics.class);
+		given(challengeService.findActiveChallengeWithStatistics(userId))
+			.willReturn(Optional.of(challenge));
+		given(challenge.getStatistics()).willReturn(stats);
+		given(stats.calculateCherryLevel()).willReturn(1);
+		given(stats.getProgressPercentage()).willReturn(10.0);
+
+		var user = UserFixture.createUser();
+		UserProcedure recent = UserProcedureFixture.createUserProcedure(
+			user,
+			ProcedureFixture.createProcedure("레이저", "레이저", 0, 5),
+			LocalDateTime.of(2026, 1, 14, 10, 0),
+			6
+		);
+		given(userProcedureService.findRecentProcedures(userId, today))
+			.willReturn(List.of(recent));
+		given(userProcedureService.findUpcomingProceduresGroupedByDate(userId, today, 3))
+			.willReturn(Map.of());
+
+		// when
+		MainDashboardResponseDto result = mainDashboardFacade.getMainDashboard(userId);
+
+		// then
+		assertThat(result.getUpcomingProcedures()).isEmpty();
+		assertThat(result.getRecentProcedures()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("챌린지/시술 데이터가 있으면 응답 매핑")
+	void getMainDashboardWithChallengeAndProcedures() {
+		// given
+		Long userId = 1L;
+		Challenge challenge = org.mockito.Mockito.mock(Challenge.class);
+		ChallengeStatistics stats = org.mockito.Mockito.mock(ChallengeStatistics.class);
+		given(challengeService.findActiveChallengeWithStatistics(userId))
+			.willReturn(Optional.of(challenge));
+		given(challenge.getStatistics()).willReturn(stats);
+		given(stats.calculateCherryLevel()).willReturn(4);
+		given(stats.getProgressPercentage()).willReturn(80.0);
+
+		var user = UserFixture.createUser();
+		UserProcedure recent1 = UserProcedureFixture.createUserProcedure(
+			user,
+			ProcedureFixture.createProcedure("레이저", "레이저", 0, 5),
+			LocalDateTime.of(2026, 1, 14, 10, 0),
+			6
+		);
+		UserProcedure recent2 = UserProcedureFixture.createUserProcedure(
+			user,
+			ProcedureFixture.createProcedure("필러", "주사", 0, 5),
+			LocalDateTime.of(2026, 1, 13, 10, 0),
+			3
+		);
+		given(userProcedureService.findRecentProcedures(userId, today))
+			.willReturn(List.of(recent1, recent2));
+
+		Map<LocalDate, List<UserProcedure>> upcoming = new LinkedHashMap<>();
+		upcoming.put(
+			LocalDate.of(2026, 1, 16),
+			List.of(
+				UserProcedureFixture.createUserProcedure(
+					user,
+					ProcedureFixture.createProcedure("보톡스", "주사", 0, 5),
+					LocalDateTime.of(2026, 1, 16, 9, 0),
+					2
+				),
+				UserProcedureFixture.createUserProcedure(
+					user,
+					ProcedureFixture.createProcedure("울쎄라", "레이저", 0, 5),
+					LocalDateTime.of(2026, 1, 16, 12, 0),
+					7
+				)
+			)
+		);
+		upcoming.put(
+			LocalDate.of(2026, 1, 17),
+			List.of(
+				UserProcedureFixture.createUserProcedure(
+					user,
+					ProcedureFixture.createProcedure("레이저 토닝", "레이저", 0, 5),
+					LocalDateTime.of(2026, 1, 17, 9, 0),
+					1
+				)
+			)
+		);
+		given(userProcedureService.findUpcomingProceduresGroupedByDate(userId, today, 3))
+			.willReturn(upcoming);
+
+		// when
+		MainDashboardResponseDto result = mainDashboardFacade.getMainDashboard(userId);
+
+		// then
+		assertThat(result.getCherryLevel()).isEqualTo(4);
+		assertThat(result.getChallengeRate()).isEqualTo(80.0);
+
+		List<RecentProcedureResponseDto> recent = result.getRecentProcedures();
+		assertThat(recent).hasSize(2);
+		assertThat(recent.get(0).getName()).isEqualTo("레이저");
+		assertThat(recent.get(0).getDaysSince()).isPositive();
+		assertThat(recent.get(1).getName()).isEqualTo("필러");
+		assertThat(recent.get(1).getDaysSince()).isPositive();
+
+		List<UpcomingProcedureResponseDto> upcomingDtos = result.getUpcomingProcedures();
+		assertThat(upcomingDtos).hasSize(2);
+		assertThat(upcomingDtos.get(0).getDate()).isEqualTo(LocalDate.of(2026, 1, 16));
+		assertThat(upcomingDtos.get(0).getName()).isEqualTo("울쎄라");
+		assertThat(upcomingDtos.get(0).getCount()).isEqualTo(2);
+		assertThat(upcomingDtos.get(0).getDDay()).isEqualTo(1);
+		assertThat(upcomingDtos.get(1).getDate()).isEqualTo(LocalDate.of(2026, 1, 17));
+		assertThat(upcomingDtos.get(1).getName()).isEqualTo("레이저 토닝");
+		assertThat(upcomingDtos.get(1).getCount()).isEqualTo(1);
+		assertThat(upcomingDtos.get(1).getDDay()).isEqualTo(2);
+	}
+}

--- a/src/test/java/com/sopt/cherrish/domain/maindashboard/presentation/MainDashboardControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/maindashboard/presentation/MainDashboardControllerTest.java
@@ -1,0 +1,175 @@
+package com.sopt.cherrish.domain.maindashboard.presentation;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.sopt.cherrish.domain.maindashboard.application.facade.MainDashboardFacade;
+import com.sopt.cherrish.domain.maindashboard.presentation.dto.response.MainDashboardResponseDto;
+import com.sopt.cherrish.domain.maindashboard.presentation.dto.response.RecentProcedureResponseDto;
+import com.sopt.cherrish.domain.maindashboard.presentation.dto.response.UpcomingProcedureResponseDto;
+import com.sopt.cherrish.domain.user.exception.UserErrorCode;
+import com.sopt.cherrish.domain.user.exception.UserException;
+import com.sopt.cherrish.domain.userprocedure.domain.model.ProcedurePhase;
+
+@WebMvcTest(MainDashboardController.class)
+@DisplayName("MainDashboardController 테스트")
+class MainDashboardControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private MainDashboardFacade mainDashboardFacade;
+
+	@Test
+	@DisplayName("성공 - 메인 대시보드 조회")
+	void getMainDashboardSuccess() throws Exception {
+		// given
+		Long userId = 1L;
+		LocalDate today = LocalDate.of(2026, 1, 15);
+		RecentProcedureResponseDto recent = RecentProcedureResponseDto.builder()
+			.name("레이저 토닝")
+			.daysSince(2)
+			.currentPhase(ProcedurePhase.CAUTION)
+			.build();
+		UpcomingProcedureResponseDto upcoming = UpcomingProcedureResponseDto.of(
+			LocalDate.of(2026, 1, 16),
+			"보톡스",
+			2,
+			today
+		);
+		MainDashboardResponseDto response = MainDashboardResponseDto.from(
+			today,
+			3,
+			55.5,
+			List.of(recent),
+			List.of(upcoming)
+		);
+
+		given(mainDashboardFacade.getMainDashboard(userId)).willReturn(response);
+
+		// when & then
+		mockMvc.perform(get("/api/main-dashboard")
+				.header("X-User-Id", userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.date").value("2026-01-15"))
+			.andExpect(jsonPath("$.data.cherryLevel").value(3))
+			.andExpect(jsonPath("$.data.challengeRate").value(55.5))
+			.andExpect(jsonPath("$.data.recentProcedures[0].name").value("레이저 토닝"))
+			.andExpect(jsonPath("$.data.upcomingProcedures[0].name").value("보톡스"));
+	}
+
+	@Test
+	@DisplayName("실패 - 존재하지 않는 사용자")
+	void getMainDashboardUserNotFound() throws Exception {
+		// given
+		Long invalidUserId = 999L;
+		given(mainDashboardFacade.getMainDashboard(invalidUserId))
+			.willThrow(new UserException(UserErrorCode.USER_NOT_FOUND));
+
+		// when & then
+		mockMvc.perform(get("/api/main-dashboard")
+				.header("X-User-Id", invalidUserId))
+			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	@DisplayName("성공 - 챌린지 없을 때 cherryLevel 0 반환")
+	void getMainDashboardWithoutChallenge() throws Exception {
+		// given
+		Long userId = 2L;
+		LocalDate today = LocalDate.of(2026, 1, 15);
+		MainDashboardResponseDto response = MainDashboardResponseDto.from(
+			today,
+			0,  // cherryLevel = 0
+			0.0,
+			List.of(),
+			List.of()
+		);
+		given(mainDashboardFacade.getMainDashboard(userId)).willReturn(response);
+
+		// when & then
+		mockMvc.perform(get("/api/main-dashboard")
+				.header("X-User-Id", userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.cherryLevel").value(0))
+			.andExpect(jsonPath("$.data.challengeRate").value(0.0))
+			.andExpect(jsonPath("$.data.recentProcedures").isArray())
+			.andExpect(jsonPath("$.data.recentProcedures").isEmpty())
+			.andExpect(jsonPath("$.data.upcomingProcedures").isArray())
+			.andExpect(jsonPath("$.data.upcomingProcedures").isEmpty());
+	}
+
+	@Test
+	@DisplayName("성공 - recentProcedures 빈 배열 반환")
+	void getMainDashboardWithEmptyRecentProcedures() throws Exception {
+		// given
+		Long userId = 3L;
+		LocalDate today = LocalDate.of(2026, 1, 15);
+		UpcomingProcedureResponseDto upcoming = UpcomingProcedureResponseDto.of(
+			LocalDate.of(2026, 1, 20),
+			"보톡스",
+			1,
+			today
+		);
+		MainDashboardResponseDto response = MainDashboardResponseDto.from(
+			today,
+			2,
+			45.0,
+			List.of(),  // 빈 리스트
+			List.of(upcoming)
+		);
+		given(mainDashboardFacade.getMainDashboard(userId)).willReturn(response);
+
+		// when & then
+		mockMvc.perform(get("/api/main-dashboard")
+				.header("X-User-Id", userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.recentProcedures").isArray())
+			.andExpect(jsonPath("$.data.recentProcedures").isEmpty())
+			.andExpect(jsonPath("$.data.upcomingProcedures").isArray())
+			.andExpect(jsonPath("$.data.upcomingProcedures[0].name").value("보톡스"));
+	}
+
+	@Test
+	@DisplayName("성공 - upcomingProcedures 빈 배열 반환")
+	void getMainDashboardWithEmptyUpcomingProcedures() throws Exception {
+		// given
+		Long userId = 4L;
+		LocalDate today = LocalDate.of(2026, 1, 15);
+		RecentProcedureResponseDto recent = RecentProcedureResponseDto.builder()
+			.name("필러")
+			.daysSince(3)
+			.currentPhase(ProcedurePhase.RECOVERY)
+			.build();
+		MainDashboardResponseDto response = MainDashboardResponseDto.from(
+			today,
+			3,
+			60.0,
+			List.of(recent),
+			List.of()  // 빈 리스트
+		);
+		given(mainDashboardFacade.getMainDashboard(userId)).willReturn(response);
+
+		// when & then
+		mockMvc.perform(get("/api/main-dashboard")
+				.header("X-User-Id", userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.recentProcedures").isArray())
+			.andExpect(jsonPath("$.data.recentProcedures[0].name").value("필러"))
+			.andExpect(jsonPath("$.data.upcomingProcedures").isArray())
+			.andExpect(jsonPath("$.data.upcomingProcedures").isEmpty());
+	}
+}

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/application/service/UserProcedureServiceTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/application/service/UserProcedureServiceTest.java
@@ -219,6 +219,7 @@ class UserProcedureServiceTest {
 		// given
 		Long userId = 1L;
 		LocalDate today = LocalDate.of(2026, 1, 15);
+		LocalDate fromDate = today.minusDays(30);
 		User user = UserFixture.createUser();
 
 		LocalDateTime baseDate = LocalDateTime.of(2026, 1, 13, 0, 0);
@@ -253,7 +254,7 @@ class UserProcedureServiceTest {
 			2
 		);
 
-		given(userProcedureRepository.findAllPastProcedures(userId, today))
+		given(userProcedureRepository.findAllPastProcedures(userId, fromDate, today))
 			.willReturn(List.of(cautionEarly, completed, recovery, sensitive, cautionLate));
 
 		// when
@@ -273,6 +274,7 @@ class UserProcedureServiceTest {
 		// given
 		Long userId = 1L;
 		LocalDate today = LocalDate.of(2026, 1, 15);
+		LocalDate fromDate = today.minusDays(30);
 		User user = UserFixture.createUser();
 
 		// 1/10 시술 (다운타임 7일) - 1/15 기준 RECOVERY
@@ -308,7 +310,7 @@ class UserProcedureServiceTest {
 			5
 		);
 
-		given(userProcedureRepository.findAllPastProcedures(userId, today))
+		given(userProcedureRepository.findAllPastProcedures(userId, fromDate, today))
 			.willReturn(List.of(jan14, jan12, jan10, jan8));
 
 		// when

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryTest.java
@@ -2,7 +2,9 @@ package com.sopt.cherrish.domain.userprocedure.domain.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -62,6 +64,107 @@ class UserProcedureRepositoryTest {
 		assertThat(found.get().getProcedure().getId()).isEqualTo(procedure.getId());
 		assertThat(found.get().getScheduledAt()).isEqualTo(scheduledAt);
 		assertThat(found.get().getDowntimeDays()).isEqualTo(5);
+	}
+
+	@Test
+	@DisplayName("가장 최근 날짜의 시술 목록 조회 성공")
+	void findProceduresOnMostRecentDate() {
+		// given
+		User user = createAndPersistUser("홍길동", 25);
+		Procedure procedure = createAndPersistProcedure("레이저 토닝", "레이저", 0, 1);
+
+		userProcedureRepository.save(UserProcedure.builder()
+			.user(user)
+			.procedure(procedure)
+			.scheduledAt(LocalDateTime.of(2026, 1, 14, 10, 0))
+			.downtimeDays(3)
+			.build());
+		userProcedureRepository.save(UserProcedure.builder()
+			.user(user)
+			.procedure(procedure)
+			.scheduledAt(LocalDateTime.of(2026, 1, 15, 9, 0))
+			.downtimeDays(5)
+			.build());
+		userProcedureRepository.save(UserProcedure.builder()
+			.user(user)
+			.procedure(procedure)
+			.scheduledAt(LocalDateTime.of(2026, 1, 15, 18, 0))
+			.downtimeDays(1)
+			.build());
+
+		entityManager.flush();
+		entityManager.clear();
+
+		// when
+		List<UserProcedure> result = userProcedureRepository.findProceduresOnMostRecentDate(
+			user.getId(), LocalDate.of(2026, 1, 15)
+		);
+
+		// then
+		assertThat(result).hasSize(2);
+		assertThat(result)
+			.allMatch(up -> up.getScheduledAt().toLocalDate().equals(LocalDate.of(2026, 1, 15)));
+	}
+
+	@Test
+	@DisplayName("가장 최근 날짜 조회 시 시술이 없으면 빈 리스트 반환")
+	void findProceduresOnMostRecentDateEmpty() {
+		// given
+		User user = createAndPersistUser("홍길동", 25);
+
+		// when
+		List<UserProcedure> result = userProcedureRepository.findProceduresOnMostRecentDate(
+			user.getId(), LocalDate.of(2026, 1, 15)
+		);
+
+		// then
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	@DisplayName("다가오는 시술 조회 - 기준일 포함 및 시간순 정렬")
+	void findUpcomingProceduresGroupedByDate() {
+		// given
+		User user = createAndPersistUser("홍길동", 25);
+		Procedure procedure = createAndPersistProcedure("레이저 토닝", "레이저", 0, 1);
+
+		userProcedureRepository.save(UserProcedure.builder()
+			.user(user)
+			.procedure(procedure)
+			.scheduledAt(LocalDateTime.of(2026, 1, 15, 9, 0))
+			.downtimeDays(1)
+			.build());
+		userProcedureRepository.save(UserProcedure.builder()
+			.user(user)
+			.procedure(procedure)
+			.scheduledAt(LocalDateTime.of(2026, 1, 16, 9, 0))
+			.downtimeDays(2)
+			.build());
+		userProcedureRepository.save(UserProcedure.builder()
+			.user(user)
+			.procedure(procedure)
+			.scheduledAt(LocalDateTime.of(2026, 1, 16, 13, 0))
+			.downtimeDays(3)
+			.build());
+		userProcedureRepository.save(UserProcedure.builder()
+			.user(user)
+			.procedure(procedure)
+			.scheduledAt(LocalDateTime.of(2026, 1, 17, 9, 0))
+			.downtimeDays(4)
+			.build());
+
+		entityManager.flush();
+		entityManager.clear();
+
+		// when
+		List<UserProcedure> result = userProcedureRepository.findUpcomingProceduresGroupedByDate(
+			user.getId(), LocalDate.of(2026, 1, 16)
+		);
+
+		// then
+		assertThat(result).hasSize(3);
+		assertThat(result.get(0).getScheduledAt()).isEqualTo(LocalDateTime.of(2026, 1, 16, 9, 0));
+		assertThat(result.get(2).getScheduledAt()).isEqualTo(LocalDateTime.of(2026, 1, 17, 9, 0));
 	}
 
 	// Helper methods

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryTest.java
@@ -102,8 +102,10 @@ class UserProcedureRepositoryTest {
 		entityManager.clear();
 
 		// when
+		LocalDate toDate = LocalDate.of(2026, 1, 15);
+		LocalDate fromDate = toDate.minusDays(30);
 		List<UserProcedure> result = userProcedureRepository.findAllPastProcedures(
-			user.getId(), LocalDate.of(2026, 1, 15)
+			user.getId(), fromDate, toDate
 		);
 
 		// then
@@ -120,8 +122,10 @@ class UserProcedureRepositoryTest {
 		User user = createAndPersistUser("홍길동", 25);
 
 		// when
+		LocalDate toDate = LocalDate.of(2026, 1, 15);
+		LocalDate fromDate = toDate.minusDays(30);
 		List<UserProcedure> result = userProcedureRepository.findAllPastProcedures(
-			user.getId(), LocalDate.of(2026, 1, 15)
+			user.getId(), fromDate, toDate
 		);
 
 		// then

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryTest.java
@@ -67,8 +67,8 @@ class UserProcedureRepositoryTest {
 	}
 
 	@Test
-	@DisplayName("가장 최근 날짜의 시술 목록 조회 성공")
-	void findProceduresOnMostRecentDate() {
+	@DisplayName("과거 모든 시술 조회 성공")
+	void findAllPastProcedures() {
 		// given
 		User user = createAndPersistUser("홍길동", 25);
 		Procedure procedure = createAndPersistProcedure("레이저 토닝", "레이저", 0, 1);
@@ -76,13 +76,13 @@ class UserProcedureRepositoryTest {
 		userProcedureRepository.save(UserProcedure.builder()
 			.user(user)
 			.procedure(procedure)
-			.scheduledAt(LocalDateTime.of(2026, 1, 14, 10, 0))
+			.scheduledAt(LocalDateTime.of(2026, 1, 10, 10, 0))
 			.downtimeDays(3)
 			.build());
 		userProcedureRepository.save(UserProcedure.builder()
 			.user(user)
 			.procedure(procedure)
-			.scheduledAt(LocalDateTime.of(2026, 1, 15, 9, 0))
+			.scheduledAt(LocalDateTime.of(2026, 1, 14, 9, 0))
 			.downtimeDays(5)
 			.build());
 		userProcedureRepository.save(UserProcedure.builder()
@@ -91,29 +91,36 @@ class UserProcedureRepositoryTest {
 			.scheduledAt(LocalDateTime.of(2026, 1, 15, 18, 0))
 			.downtimeDays(1)
 			.build());
+		userProcedureRepository.save(UserProcedure.builder()
+			.user(user)
+			.procedure(procedure)
+			.scheduledAt(LocalDateTime.of(2026, 1, 16, 9, 0))
+			.downtimeDays(2)
+			.build());
 
 		entityManager.flush();
 		entityManager.clear();
 
 		// when
-		List<UserProcedure> result = userProcedureRepository.findProceduresOnMostRecentDate(
+		List<UserProcedure> result = userProcedureRepository.findAllPastProcedures(
 			user.getId(), LocalDate.of(2026, 1, 15)
 		);
 
 		// then
-		assertThat(result).hasSize(2);
-		assertThat(result)
-			.allMatch(up -> up.getScheduledAt().toLocalDate().equals(LocalDate.of(2026, 1, 15)));
+		assertThat(result).hasSize(3);
+		assertThat(result.get(0).getScheduledAt()).isEqualTo(LocalDateTime.of(2026, 1, 15, 18, 0));
+		assertThat(result.get(1).getScheduledAt()).isEqualTo(LocalDateTime.of(2026, 1, 14, 9, 0));
+		assertThat(result.get(2).getScheduledAt()).isEqualTo(LocalDateTime.of(2026, 1, 10, 10, 0));
 	}
 
 	@Test
-	@DisplayName("가장 최근 날짜 조회 시 시술이 없으면 빈 리스트 반환")
-	void findProceduresOnMostRecentDateEmpty() {
+	@DisplayName("과거 시술 조회 시 시술이 없으면 빈 리스트 반환")
+	void findAllPastProceduresEmpty() {
 		// given
 		User user = createAndPersistUser("홍길동", 25);
 
 		// when
-		List<UserProcedure> result = userProcedureRepository.findProceduresOnMostRecentDate(
+		List<UserProcedure> result = userProcedureRepository.findAllPastProcedures(
 			user.getId(), LocalDate.of(2026, 1, 15)
 		);
 


### PR DESCRIPTION
# 🛠 Related issue 🛠
- closed #14 

# ✏️ Work Description ✏️
- 메인 대시보드 조회 API 구현
  - GET`/api/main-dashboard` 엔드포인트 추가
  - 사용자의 체리 레벨, 챌린지 진행률, 다운타임 진행 중인 시술, 예정된 시술 정보 제공
- 비즈니스 로직
  - 다운타임 진행 중인 시술 조회
    - 과거 받은 모든 시술 중 현재 다운타임(민감기/주의기/회복기) 진행 중인 시술만 필터링
    - 정렬: Phase 우선(SENSITIVE > CAUTION > RECOVERY) → 같은 Phase면 최근 시술 먼저
    - COMPLETED(완료) 시술 제외
  - 예정된 시술 조회
    - 내일(D-1)부터 시작하는 미래 시술을 날짜별로 그룹핑
    - 가장 가까운 3개 날짜만 반환
    - 각 날짜마다: 다운타임이 가장 긴 시술명 + 해당 날짜 총 시술 개수 + D-Day
 - MainDashboardFacade: 여러 도메인 서비스 조합
    - UserService: 사용자 검증
    - ChallengeService: 챌린지 정보 조회
    - UserProcedureService: 시술 정보 조회
- DowntimePeriod Value Object: 다운타임 기간 계산 로직 캡슐화
   - 총 다운타임을 민감기(1/3), 주의기(1/3), 회복기(1/3)로 분할
   - 나머지 일수는 민감기/주의기에 우선 배분
- 테스트 코드 구현
  - MainDashboardFacadeTest (6개 테스트)
    - ✅ 챌린지/시술 모두 없는 경우
    - ✅ 챌린지 없고 시술 있는 경우
    - ✅ 최근 시술 없고 예정 시술 있는 경우
    - ✅ 예정 시술 없고 최근 시술 있는 경우
    - ✅ 여러 날짜에 걸친 다운타임 진행 중인 시술 응답 (핵심 엣지케이스)
    - ✅ 챌린지/시술 모두 있는 경우
  - MainDashboardControllerTest (5개 테스트)
    - ✅ 성공 케이스
    - ✅ 404 에러 (사용자 없음)
    - ✅ cherryLevel=0 케이스
    - ✅ recentProcedures 빈 배열 케이스
    - ✅ upcomingProcedures 빈 배열 케이스
  - UserProcedureServiceTest (3개 테스트)
    - ✅ COMPLETED 제외 및 Phase/시간 순 정렬
    - ✅ 여러 날짜에 걸친 다운타임 진행 중인 시술 조회 (핵심 엣지케이스)
    - ✅ 날짜별 그룹핑 및 최대 3개 날짜 제한
  - UserProcedureRepositoryTest (3개 테스트)
    - ✅ 과거 모든 시술 조회
    - ✅ 빈 리스트 반환
    - ✅ 다가오는 시술 조회 및 정렬

# 📸 Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 메인 대시보드 조회 | <img width="280" height="397" alt="스크린샷 2026-01-12 오후 9 44 46" src="https://github.com/user-attachments/assets/aa9a4f5d-e37a-4946-be3b-02c1ed630f50" /> |
| 회복 중인 최근 시술 없을 경우 | <img width="217" height="290" alt="스크린샷 2026-01-12 오후 9 45 25" src="https://github.com/user-attachments/assets/c3c72275-4c37-48fd-89a0-7702ecc7881a" /> |

# 😅 Uncompleted Tasks 😅
- 

# 📢 To Reviewers 📢
- 

