### PR TITLE
[Enhancement] 시술 응답구조 피부고민 리스트 포함하도록 변경

### DIFF
--- a/src/main/java/com/sopt/cherrish/domain/procedure/application/service/ProcedureService.java
+++ b/src/main/java/com/sopt/cherrish/domain/procedure/application/service/ProcedureService.java
@@ -3,6 +3,8 @@ package com.sopt.cherrish.domain.procedure.application.service;
 import java.text.Collator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,6 +13,7 @@ import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
 import com.sopt.cherrish.domain.procedure.domain.repository.ProcedureRepository;
 import com.sopt.cherrish.domain.procedure.presentation.dto.response.ProcedureListResponseDto;
 import com.sopt.cherrish.domain.procedure.presentation.dto.response.ProcedureResponseDto;
+import com.sopt.cherrish.domain.worry.presentation.dto.response.WorryResponseDto;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,18 +22,40 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class ProcedureService {
 
-    private static final Collator KOREAN_COLLATOR = Collator.getInstance(Locale.KOREAN);
+	private static final Collator KOREAN_COLLATOR = Collator.getInstance(Locale.KOREAN);
 	private final ProcedureRepository procedureRepository;
 
 	public ProcedureListResponseDto searchProcedures(String keyword, Long worryId) {
 		List<Procedure> procedures = procedureRepository.searchProcedures(keyword, worryId);
+		Map<Long, List<WorryResponseDto>> worriesByProcedureId = fetchWorriesByProcedure(procedures);
 
 		// DB의 한글 collation 설정과 무관하게 정확한 한글 정렬을 보장하기 위해 Java에서 정렬
 		return ProcedureListResponseDto.of(
 			procedures.stream()
-				.map(ProcedureResponseDto::from)
-                .sorted((p1, p2) -> KOREAN_COLLATOR.compare(p1.getName(), p2.getName()))
+				.map(procedure -> ProcedureResponseDto.from(
+					procedure,
+					worriesByProcedureId.getOrDefault(procedure.getId(), List.of())
+				))
+				.sorted((p1, p2) -> KOREAN_COLLATOR.compare(p1.getName(), p2.getName()))
 				.toList()
 		);
+	}
+
+	private Map<Long, List<WorryResponseDto>> fetchWorriesByProcedure(List<Procedure> procedures) {
+		List<Long> procedureIds = procedures.stream()
+			.map(Procedure::getId)
+			.toList();
+		if (procedureIds.isEmpty()) {
+			return Map.of();
+		}
+
+		return procedureRepository.findAllByProcedureIdInWithWorry(procedureIds).stream()
+			.collect(Collectors.groupingBy(
+				procedureWorry -> procedureWorry.getProcedure().getId(),
+				Collectors.mapping(
+					procedureWorry -> WorryResponseDto.from(procedureWorry.getWorry()),
+					Collectors.toList()
+				)
+			));
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/procedure/application/service/ProcedureService.java
+++ b/src/main/java/com/sopt/cherrish/domain/procedure/application/service/ProcedureService.java
@@ -30,14 +30,16 @@ public class ProcedureService {
 	public ProcedureListResponseDto searchProcedures(String keyword, Long worryId) {
 		List<Procedure> procedures = procedureRepository.searchProcedures(keyword, worryId);
 		Map<Long, List<ProcedureWorryResponseDto>> worriesByProcedureId = fetchWorriesByProcedure(procedures);
+		List<ProcedureResponseDto> responses = procedures.stream()
+			.map(procedure -> ProcedureResponseDto.from(
+				procedure,
+				worriesByProcedureId.getOrDefault(procedure.getId(), List.of())
+			))
+			.toList();
 
 		// DB의 한글 collation 설정과 무관하게 정확한 한글 정렬을 보장하기 위해 Java에서 정렬
 		return ProcedureListResponseDto.of(
-			procedures.stream()
-				.map(procedure -> ProcedureResponseDto.from(
-					procedure,
-					worriesByProcedureId.getOrDefault(procedure.getId(), List.of())
-				))
+			responses.stream()
 				.sorted((p1, p2) -> KOREAN_COLLATOR.compare(p1.getName(), p2.getName()))
 				.toList()
 		);

--- a/src/main/java/com/sopt/cherrish/domain/procedure/domain/repository/ProcedureRepositoryCustom.java
+++ b/src/main/java/com/sopt/cherrish/domain/procedure/domain/repository/ProcedureRepositoryCustom.java
@@ -3,6 +3,7 @@ package com.sopt.cherrish.domain.procedure.domain.repository;
 import java.util.List;
 
 import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
+import com.sopt.cherrish.domain.procedure.domain.model.ProcedureWorry;
 
 public interface ProcedureRepositoryCustom {
 
@@ -13,4 +14,10 @@ public interface ProcedureRepositoryCustom {
 	 * - DISTINCT로 중복 제거 (한 시술이 여러 고민과 매핑되는 경우)
 	 */
 	List<Procedure> searchProcedures(String keyword, Long worryId);
+
+	/**
+	 * 시술 ID 목록으로 ProcedureWorry 조회 (Worry fetch join)
+	 * - N+1 문제 방지를 위해 Worry를 한 번에 가져옴
+	 */
+	List<ProcedureWorry> findAllByProcedureIdInWithWorry(List<Long> procedureIds);
 }

--- a/src/main/java/com/sopt/cherrish/domain/procedure/domain/repository/ProcedureRepositoryCustom.java
+++ b/src/main/java/com/sopt/cherrish/domain/procedure/domain/repository/ProcedureRepositoryCustom.java
@@ -3,7 +3,6 @@ package com.sopt.cherrish.domain.procedure.domain.repository;
 import java.util.List;
 
 import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
-import com.sopt.cherrish.domain.procedure.domain.model.ProcedureWorry;
 
 public interface ProcedureRepositoryCustom {
 
@@ -15,9 +14,4 @@ public interface ProcedureRepositoryCustom {
 	 */
 	List<Procedure> searchProcedures(String keyword, Long worryId);
 
-	/**
-	 * 시술 ID 목록으로 ProcedureWorry 조회 (Worry fetch join)
-	 * - N+1 문제 방지를 위해 Worry를 한 번에 가져옴
-	 */
-	List<ProcedureWorry> findAllByProcedureIdInWithWorry(List<Long> procedureIds);
 }

--- a/src/main/java/com/sopt/cherrish/domain/procedure/domain/repository/ProcedureRepositoryImpl.java
+++ b/src/main/java/com/sopt/cherrish/domain/procedure/domain/repository/ProcedureRepositoryImpl.java
@@ -5,13 +5,11 @@ import java.util.List;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
-import com.sopt.cherrish.domain.procedure.domain.model.ProcedureWorry;
 
 import lombok.RequiredArgsConstructor;
 
 import static com.sopt.cherrish.domain.procedure.domain.model.QProcedure.procedure;
 import static com.sopt.cherrish.domain.procedure.domain.model.QProcedureWorry.procedureWorry;
-import static com.sopt.cherrish.domain.worry.domain.model.QWorry.worry;
 
 @RequiredArgsConstructor
 public class ProcedureRepositoryImpl implements ProcedureRepositoryCustom {
@@ -36,15 +34,6 @@ public class ProcedureRepositoryImpl implements ProcedureRepositoryCustom {
 		return queryFactory
 			.selectFrom(procedure)
 			.where(containsKeyword(keyword))
-			.fetch();
-	}
-
-	@Override
-	public List<ProcedureWorry> findAllByProcedureIdInWithWorry(List<Long> procedureIds) {
-		return queryFactory
-			.selectFrom(procedureWorry)
-			.join(procedureWorry.worry, worry).fetchJoin()
-			.where(procedureWorry.procedure.id.in(procedureIds))
 			.fetch();
 	}
 

--- a/src/main/java/com/sopt/cherrish/domain/procedure/domain/repository/ProcedureRepositoryImpl.java
+++ b/src/main/java/com/sopt/cherrish/domain/procedure/domain/repository/ProcedureRepositoryImpl.java
@@ -5,11 +5,13 @@ import java.util.List;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
+import com.sopt.cherrish.domain.procedure.domain.model.ProcedureWorry;
 
 import lombok.RequiredArgsConstructor;
 
 import static com.sopt.cherrish.domain.procedure.domain.model.QProcedure.procedure;
 import static com.sopt.cherrish.domain.procedure.domain.model.QProcedureWorry.procedureWorry;
+import static com.sopt.cherrish.domain.worry.domain.model.QWorry.worry;
 
 @RequiredArgsConstructor
 public class ProcedureRepositoryImpl implements ProcedureRepositoryCustom {
@@ -34,6 +36,15 @@ public class ProcedureRepositoryImpl implements ProcedureRepositoryCustom {
 		return queryFactory
 			.selectFrom(procedure)
 			.where(containsKeyword(keyword))
+			.fetch();
+	}
+
+	@Override
+	public List<ProcedureWorry> findAllByProcedureIdInWithWorry(List<Long> procedureIds) {
+		return queryFactory
+			.selectFrom(procedureWorry)
+			.join(procedureWorry.worry, worry).fetchJoin()
+			.where(procedureWorry.procedure.id.in(procedureIds))
 			.fetch();
 	}
 

--- a/src/main/java/com/sopt/cherrish/domain/procedure/domain/repository/ProcedureWorryRepository.java
+++ b/src/main/java/com/sopt/cherrish/domain/procedure/domain/repository/ProcedureWorryRepository.java
@@ -17,4 +17,16 @@ public interface ProcedureWorryRepository extends JpaRepository<ProcedureWorry, 
 		where pw.procedure.id in :procedureIds
 		""")
 	List<ProcedureWorry> findAllByProcedureIdInWithWorry(@Param("procedureIds") List<Long> procedureIds);
+
+	@Query("""
+		select pw
+		from ProcedureWorry pw
+		join fetch pw.worry
+		where pw.procedure.id in :procedureIds
+		and pw.worry.id = :worryId
+		""")
+	List<ProcedureWorry> findAllByProcedureIdInWithWorryAndWorryId(
+		@Param("procedureIds") List<Long> procedureIds,
+		@Param("worryId") Long worryId
+	);
 }

--- a/src/main/java/com/sopt/cherrish/domain/procedure/domain/repository/ProcedureWorryRepository.java
+++ b/src/main/java/com/sopt/cherrish/domain/procedure/domain/repository/ProcedureWorryRepository.java
@@ -1,0 +1,20 @@
+package com.sopt.cherrish.domain.procedure.domain.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.sopt.cherrish.domain.procedure.domain.model.ProcedureWorry;
+
+public interface ProcedureWorryRepository extends JpaRepository<ProcedureWorry, Long> {
+
+	@Query("""
+		select pw
+		from ProcedureWorry pw
+		join fetch pw.worry
+		where pw.procedure.id in :procedureIds
+		""")
+	List<ProcedureWorry> findAllByProcedureIdInWithWorry(@Param("procedureIds") List<Long> procedureIds);
+}

--- a/src/main/java/com/sopt/cherrish/domain/procedure/domain/repository/ProcedureWorryRepository.java
+++ b/src/main/java/com/sopt/cherrish/domain/procedure/domain/repository/ProcedureWorryRepository.java
@@ -1,8 +1,0 @@
-package com.sopt.cherrish.domain.procedure.domain.repository;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import com.sopt.cherrish.domain.procedure.domain.model.ProcedureWorry;
-
-public interface ProcedureWorryRepository extends JpaRepository<ProcedureWorry, Long> {
-}

--- a/src/main/java/com/sopt/cherrish/domain/procedure/domain/repository/ProcedureWorryRepository.java
+++ b/src/main/java/com/sopt/cherrish/domain/procedure/domain/repository/ProcedureWorryRepository.java
@@ -10,11 +10,15 @@ import com.sopt.cherrish.domain.procedure.domain.model.ProcedureWorry;
 
 public interface ProcedureWorryRepository extends JpaRepository<ProcedureWorry, Long> {
 
-	@Query("""
-		select pw
-		from ProcedureWorry pw
-		join fetch pw.worry
-		where pw.procedure.id in :procedureIds
-		""")
+	@Query("SELECT pw FROM ProcedureWorry pw JOIN FETCH pw.worry WHERE pw.procedure.id IN :procedureIds")
 	List<ProcedureWorry> findAllByProcedureIdInWithWorry(@Param("procedureIds") List<Long> procedureIds);
+
+	@Query(
+		"SELECT pw FROM ProcedureWorry pw JOIN FETCH pw.worry "
+			+ "WHERE pw.procedure.id IN :procedureIds AND pw.worry.id = :worryId"
+	)
+	List<ProcedureWorry> findAllByProcedureIdInWithWorryAndWorryId(
+		@Param("procedureIds") List<Long> procedureIds,
+		@Param("worryId") Long worryId
+	);
 }

--- a/src/main/java/com/sopt/cherrish/domain/procedure/domain/repository/ProcedureWorryRepository.java
+++ b/src/main/java/com/sopt/cherrish/domain/procedure/domain/repository/ProcedureWorryRepository.java
@@ -10,21 +10,13 @@ import com.sopt.cherrish.domain.procedure.domain.model.ProcedureWorry;
 
 public interface ProcedureWorryRepository extends JpaRepository<ProcedureWorry, Long> {
 
-	@Query("""
-		select pw
-		from ProcedureWorry pw
-		join fetch pw.worry
-		where pw.procedure.id in :procedureIds
-		""")
+	@Query("SELECT pw FROM ProcedureWorry pw JOIN FETCH pw.worry WHERE pw.procedure.id IN :procedureIds")
 	List<ProcedureWorry> findAllByProcedureIdInWithWorry(@Param("procedureIds") List<Long> procedureIds);
 
-	@Query("""
-		select pw
-		from ProcedureWorry pw
-		join fetch pw.worry
-		where pw.procedure.id in :procedureIds
-		and pw.worry.id = :worryId
-		""")
+	@Query(
+		"SELECT pw FROM ProcedureWorry pw JOIN FETCH pw.worry "
+			+ "WHERE pw.procedure.id IN :procedureIds AND pw.worry.id = :worryId"
+	)
 	List<ProcedureWorry> findAllByProcedureIdInWithWorryAndWorryId(
 		@Param("procedureIds") List<Long> procedureIds,
 		@Param("worryId") Long worryId

--- a/src/main/java/com/sopt/cherrish/domain/procedure/presentation/dto/response/ProcedureResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/procedure/presentation/dto/response/ProcedureResponseDto.java
@@ -1,6 +1,9 @@
 package com.sopt.cherrish.domain.procedure.presentation.dto.response;
 
+import java.util.List;
+
 import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
+import com.sopt.cherrish.domain.worry.presentation.dto.response.WorryResponseDto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -17,8 +20,8 @@ public class ProcedureResponseDto {
 	@Schema(description = "시술명", example = "레이저 토닝")
 	private String name;
 
-	@Schema(description = "카테고리", example = "레이저")
-	private String category;
+	@Schema(description = "피부 고민 목록")
+	private List<WorryResponseDto> worries;
 
 	@Schema(description = "최소 다운타임 일수", example = "1")
 	private int minDowntimeDays;
@@ -26,11 +29,11 @@ public class ProcedureResponseDto {
 	@Schema(description = "최대 다운타임 일수", example = "5")
 	private int maxDowntimeDays;
 
-	public static ProcedureResponseDto from(Procedure procedure) {
+	public static ProcedureResponseDto from(Procedure procedure, List<WorryResponseDto> worries) {
 		return ProcedureResponseDto.builder()
 			.id(procedure.getId())
 			.name(procedure.getName())
-			.category(procedure.getCategory())
+			.worries(worries)
 			.minDowntimeDays(procedure.getMinDowntimeDays())
 			.maxDowntimeDays(procedure.getMaxDowntimeDays())
 			.build();

--- a/src/main/java/com/sopt/cherrish/domain/procedure/presentation/dto/response/ProcedureResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/procedure/presentation/dto/response/ProcedureResponseDto.java
@@ -3,7 +3,6 @@ package com.sopt.cherrish.domain.procedure.presentation.dto.response;
 import java.util.List;
 
 import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
-import com.sopt.cherrish.domain.worry.presentation.dto.response.WorryResponseDto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -21,7 +20,7 @@ public class ProcedureResponseDto {
 	private String name;
 
 	@Schema(description = "피부 고민 목록")
-	private List<WorryResponseDto> worries;
+	private List<ProcedureWorryResponseDto> worries;
 
 	@Schema(description = "최소 다운타임 일수", example = "1")
 	private int minDowntimeDays;
@@ -29,7 +28,7 @@ public class ProcedureResponseDto {
 	@Schema(description = "최대 다운타임 일수", example = "5")
 	private int maxDowntimeDays;
 
-	public static ProcedureResponseDto from(Procedure procedure, List<WorryResponseDto> worries) {
+	public static ProcedureResponseDto from(Procedure procedure, List<ProcedureWorryResponseDto> worries) {
 		return ProcedureResponseDto.builder()
 			.id(procedure.getId())
 			.name(procedure.getName())

--- a/src/main/java/com/sopt/cherrish/domain/procedure/presentation/dto/response/ProcedureWorryResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/procedure/presentation/dto/response/ProcedureWorryResponseDto.java
@@ -1,0 +1,26 @@
+package com.sopt.cherrish.domain.procedure.presentation.dto.response;
+
+import com.sopt.cherrish.domain.worry.domain.model.Worry;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "시술 관련 피부 고민 응답")
+public class ProcedureWorryResponseDto {
+
+	@Schema(description = "피부 고민 ID", example = "1")
+	private Long id;
+
+	@Schema(description = "피부 고민 내용", example = "여드름/트러블")
+	private String content;
+
+	public static ProcedureWorryResponseDto from(Worry worry) {
+		return ProcedureWorryResponseDto.builder()
+			.id(worry.getId())
+			.content(worry.getContent())
+			.build();
+	}
+}

--- a/src/test/java/com/sopt/cherrish/domain/procedure/application/service/ProcedureServiceTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/procedure/application/service/ProcedureServiceTest.java
@@ -16,10 +16,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
+import com.sopt.cherrish.domain.procedure.domain.model.ProcedureWorry;
 import com.sopt.cherrish.domain.procedure.domain.repository.ProcedureRepository;
 import com.sopt.cherrish.domain.procedure.domain.repository.ProcedureWorryRepository;
 import com.sopt.cherrish.domain.procedure.fixture.ProcedureFixture;
 import com.sopt.cherrish.domain.procedure.presentation.dto.response.ProcedureListResponseDto;
+import com.sopt.cherrish.domain.worry.domain.model.Worry;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ProcedureService 단위 테스트")
@@ -43,7 +45,11 @@ class ProcedureServiceTest {
 
         List<Procedure> procedures = Arrays.asList(procedure1, procedure2);
 		given(procedureRepository.searchProcedures(null, null)).willReturn(procedures);
-		given(procedureWorryRepository.findAllByProcedureIdInWithWorry(any())).willReturn(Collections.emptyList());
+		given(procedureWorryRepository.findAllByProcedureIdInWithWorry(any()))
+			.willReturn(List.of(
+				procedureWorry(procedure1, "탄력/주름"),
+				procedureWorry(procedure2, "여드름/트러블")
+			));
 
 		// when
 		ProcedureListResponseDto result = procedureService.searchProcedures(null, null);
@@ -63,7 +69,8 @@ class ProcedureServiceTest {
 		Procedure procedure = ProcedureFixture.createProcedure("레이저 토닝", "레이저", 0, 1);
 
 		given(procedureRepository.searchProcedures(keyword, null)).willReturn(Collections.singletonList(procedure));
-		given(procedureWorryRepository.findAllByProcedureIdInWithWorry(any())).willReturn(Collections.emptyList());
+		given(procedureWorryRepository.findAllByProcedureIdInWithWorry(any()))
+			.willReturn(List.of(procedureWorry(procedure, "여드름/트러블")));
 
 		// when
 		ProcedureListResponseDto result = procedureService.searchProcedures(keyword, null);
@@ -71,7 +78,7 @@ class ProcedureServiceTest {
 		// then
 		assertThat(result.getProcedures()).hasSize(1);
 		assertThat(result.getProcedures().get(0).getName()).isEqualTo("레이저 토닝");
-		assertThat(result.getProcedures().get(0).getWorries()).isEmpty();
+		assertThat(result.getProcedures().get(0).getWorries()).hasSize(1);
 	}
 
 	@Test
@@ -82,7 +89,8 @@ class ProcedureServiceTest {
 		Procedure procedure = ProcedureFixture.createProcedure("레이저 토닝", "레이저", 0, 1);
 
 		given(procedureRepository.searchProcedures(null, worryId)).willReturn(Collections.singletonList(procedure));
-		given(procedureWorryRepository.findAllByProcedureIdInWithWorry(any())).willReturn(Collections.emptyList());
+		given(procedureWorryRepository.findAllByProcedureIdInWithWorry(any()))
+			.willReturn(List.of(procedureWorry(procedure, "여드름/트러블")));
 
 		// when
 		ProcedureListResponseDto result = procedureService.searchProcedures(null, worryId);
@@ -102,7 +110,8 @@ class ProcedureServiceTest {
 
         given(procedureRepository.searchProcedures(keyword, worryId))
                 .willReturn(Collections.singletonList(procedure));
-		given(procedureWorryRepository.findAllByProcedureIdInWithWorry(any())).willReturn(Collections.emptyList());
+		given(procedureWorryRepository.findAllByProcedureIdInWithWorry(any()))
+			.willReturn(List.of(procedureWorry(procedure, "여드름/트러블")));
 
         // when
         ProcedureListResponseDto result = procedureService.searchProcedures(keyword, worryId);
@@ -110,7 +119,7 @@ class ProcedureServiceTest {
         // then
         assertThat(result.getProcedures()).hasSize(1);
         assertThat(result.getProcedures().get(0).getName()).isEqualTo("레이저 토닝");
-        assertThat(result.getProcedures().get(0).getWorries()).isEmpty();
+        assertThat(result.getProcedures().get(0).getWorries()).hasSize(1);
     }
 
     @Test
@@ -150,7 +159,8 @@ class ProcedureServiceTest {
 
 		given(procedureRepository.searchProcedures(null, null))
 			.willReturn(Collections.singletonList(procedure));
-		given(procedureWorryRepository.findAllByProcedureIdInWithWorry(any())).willReturn(Collections.emptyList());
+		given(procedureWorryRepository.findAllByProcedureIdInWithWorry(any()))
+			.willReturn(List.of(procedureWorry(procedure, "탄력/주름")));
 
 		// when
 		ProcedureListResponseDto result = procedureService.searchProcedures(null, null);
@@ -159,8 +169,18 @@ class ProcedureServiceTest {
 		assertThat(result.getProcedures()).hasSize(1);
 		assertThat(result.getProcedures().get(0).getId()).isNotNull();
 		assertThat(result.getProcedures().get(0).getName()).isEqualTo("프락셀 레이저");
-		assertThat(result.getProcedures().get(0).getWorries()).isEmpty();
+		assertThat(result.getProcedures().get(0).getWorries()).hasSize(1);
 		assertThat(result.getProcedures().get(0).getMinDowntimeDays()).isEqualTo(3);
 		assertThat(result.getProcedures().get(0).getMaxDowntimeDays()).isEqualTo(7);
+	}
+
+	private ProcedureWorry procedureWorry(Procedure procedure, String worryContent) {
+		Worry worry = Worry.builder()
+			.content(worryContent)
+			.build();
+		return ProcedureWorry.builder()
+			.procedure(procedure)
+			.worry(worry)
+			.build();
 	}
 }

--- a/src/test/java/com/sopt/cherrish/domain/procedure/application/service/ProcedureServiceTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/procedure/application/service/ProcedureServiceTest.java
@@ -2,6 +2,7 @@ package com.sopt.cherrish.domain.procedure.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.ArgumentMatchers.any;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -16,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
 import com.sopt.cherrish.domain.procedure.domain.repository.ProcedureRepository;
+import com.sopt.cherrish.domain.procedure.domain.repository.ProcedureWorryRepository;
 import com.sopt.cherrish.domain.procedure.fixture.ProcedureFixture;
 import com.sopt.cherrish.domain.procedure.presentation.dto.response.ProcedureListResponseDto;
 
@@ -29,6 +31,9 @@ class ProcedureServiceTest {
 	@Mock
 	private ProcedureRepository procedureRepository;
 
+	@Mock
+	private ProcedureWorryRepository procedureWorryRepository;
+
 	@Test
 	@DisplayName("시술 검색 성공 - keyword, worryId 둘 다 null")
 	void searchProceduresWithNoFilters() {
@@ -38,6 +43,7 @@ class ProcedureServiceTest {
 
         List<Procedure> procedures = Arrays.asList(procedure1, procedure2);
 		given(procedureRepository.searchProcedures(null, null)).willReturn(procedures);
+		given(procedureWorryRepository.findAllByProcedureIdInWithWorry(any())).willReturn(Collections.emptyList());
 
 		// when
 		ProcedureListResponseDto result = procedureService.searchProcedures(null, null);
@@ -57,6 +63,7 @@ class ProcedureServiceTest {
 		Procedure procedure = ProcedureFixture.createProcedure("레이저 토닝", "레이저", 0, 1);
 
 		given(procedureRepository.searchProcedures(keyword, null)).willReturn(Collections.singletonList(procedure));
+		given(procedureWorryRepository.findAllByProcedureIdInWithWorry(any())).willReturn(Collections.emptyList());
 
 		// when
 		ProcedureListResponseDto result = procedureService.searchProcedures(keyword, null);
@@ -64,7 +71,7 @@ class ProcedureServiceTest {
 		// then
 		assertThat(result.getProcedures()).hasSize(1);
 		assertThat(result.getProcedures().get(0).getName()).isEqualTo("레이저 토닝");
-		assertThat(result.getProcedures().get(0).getCategory()).isEqualTo("레이저");
+		assertThat(result.getProcedures().get(0).getWorries()).isEmpty();
 	}
 
 	@Test
@@ -75,6 +82,7 @@ class ProcedureServiceTest {
 		Procedure procedure = ProcedureFixture.createProcedure("레이저 토닝", "레이저", 0, 1);
 
 		given(procedureRepository.searchProcedures(null, worryId)).willReturn(Collections.singletonList(procedure));
+		given(procedureWorryRepository.findAllByProcedureIdInWithWorry(any())).willReturn(Collections.emptyList());
 
 		// when
 		ProcedureListResponseDto result = procedureService.searchProcedures(null, worryId);
@@ -94,6 +102,7 @@ class ProcedureServiceTest {
 
         given(procedureRepository.searchProcedures(keyword, worryId))
                 .willReturn(Collections.singletonList(procedure));
+		given(procedureWorryRepository.findAllByProcedureIdInWithWorry(any())).willReturn(Collections.emptyList());
 
         // when
         ProcedureListResponseDto result = procedureService.searchProcedures(keyword, worryId);
@@ -101,7 +110,7 @@ class ProcedureServiceTest {
         // then
         assertThat(result.getProcedures()).hasSize(1);
         assertThat(result.getProcedures().get(0).getName()).isEqualTo("레이저 토닝");
-        assertThat(result.getProcedures().get(0).getCategory()).isEqualTo("레이저");
+        assertThat(result.getProcedures().get(0).getWorries()).isEmpty();
     }
 
     @Test
@@ -141,6 +150,7 @@ class ProcedureServiceTest {
 
 		given(procedureRepository.searchProcedures(null, null))
 			.willReturn(Collections.singletonList(procedure));
+		given(procedureWorryRepository.findAllByProcedureIdInWithWorry(any())).willReturn(Collections.emptyList());
 
 		// when
 		ProcedureListResponseDto result = procedureService.searchProcedures(null, null);
@@ -149,7 +159,7 @@ class ProcedureServiceTest {
 		assertThat(result.getProcedures()).hasSize(1);
 		assertThat(result.getProcedures().get(0).getId()).isNotNull();
 		assertThat(result.getProcedures().get(0).getName()).isEqualTo("프락셀 레이저");
-		assertThat(result.getProcedures().get(0).getCategory()).isEqualTo("레이저");
+		assertThat(result.getProcedures().get(0).getWorries()).isEmpty();
 		assertThat(result.getProcedures().get(0).getMinDowntimeDays()).isEqualTo(3);
 		assertThat(result.getProcedures().get(0).getMaxDowntimeDays()).isEqualTo(7);
 	}

--- a/src/test/java/com/sopt/cherrish/domain/procedure/application/service/ProcedureServiceTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/procedure/application/service/ProcedureServiceTest.java
@@ -89,7 +89,7 @@ class ProcedureServiceTest {
 		Procedure procedure = ProcedureFixture.createProcedure("레이저 토닝", "레이저", 0, 1);
 
 		given(procedureRepository.searchProcedures(null, worryId)).willReturn(Collections.singletonList(procedure));
-		given(procedureWorryRepository.findAllByProcedureIdInWithWorry(any()))
+		given(procedureWorryRepository.findAllByProcedureIdInWithWorryAndWorryId(any(), any()))
 			.willReturn(List.of(procedureWorry(procedure, "여드름/트러블")));
 
 		// when
@@ -110,7 +110,7 @@ class ProcedureServiceTest {
 
         given(procedureRepository.searchProcedures(keyword, worryId))
                 .willReturn(Collections.singletonList(procedure));
-		given(procedureWorryRepository.findAllByProcedureIdInWithWorry(any()))
+		given(procedureWorryRepository.findAllByProcedureIdInWithWorryAndWorryId(any(), any()))
 			.willReturn(List.of(procedureWorry(procedure, "여드름/트러블")));
 
         // when

--- a/src/test/java/com/sopt/cherrish/domain/procedure/application/service/ProcedureServiceTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/procedure/application/service/ProcedureServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
 import com.sopt.cherrish.domain.procedure.domain.model.ProcedureWorry;
@@ -178,6 +179,7 @@ class ProcedureServiceTest {
 		Worry worry = Worry.builder()
 			.content(worryContent)
 			.build();
+		ReflectionTestUtils.setField(worry, "id", 1L);
 		return ProcedureWorry.builder()
 			.procedure(procedure)
 			.worry(worry)

--- a/src/test/java/com/sopt/cherrish/domain/procedure/presentation/ProcedureControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/procedure/presentation/ProcedureControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.sopt.cherrish.domain.procedure.application.service.ProcedureService;
 import com.sopt.cherrish.domain.procedure.presentation.dto.response.ProcedureListResponseDto;
 import com.sopt.cherrish.domain.procedure.presentation.dto.response.ProcedureResponseDto;
+import com.sopt.cherrish.domain.procedure.presentation.dto.response.ProcedureWorryResponseDto;
 
 @WebMvcTest(ProcedureController.class)
 @DisplayName("ProcedureController 통합 테스트")
@@ -37,7 +38,7 @@ class ProcedureControllerTest {
 		ProcedureResponseDto procedure1 = ProcedureResponseDto.builder()
 			.id(1L)
 			.name("레이저 토닝")
-			.worries(Collections.emptyList())
+			.worries(Collections.singletonList(worryResponse(1L, "여드름/트러블")))
 			.minDowntimeDays(0)
 			.maxDowntimeDays(1)
 			.build();
@@ -45,7 +46,7 @@ class ProcedureControllerTest {
 		ProcedureResponseDto procedure2 = ProcedureResponseDto.builder()
 			.id(2L)
 			.name("필러")
-			.worries(Collections.emptyList())
+			.worries(Collections.singletonList(worryResponse(2L, "탄력/주름")))
 			.minDowntimeDays(1)
 			.maxDowntimeDays(3)
 			.build();
@@ -72,7 +73,7 @@ class ProcedureControllerTest {
 		ProcedureResponseDto procedure = ProcedureResponseDto.builder()
 			.id(1L)
 			.name("레이저 토닝")
-			.worries(Collections.emptyList())
+			.worries(Collections.singletonList(worryResponse(1L, "여드름/트러블")))
 			.minDowntimeDays(0)
 			.maxDowntimeDays(1)
 			.build();
@@ -100,7 +101,7 @@ class ProcedureControllerTest {
 		ProcedureResponseDto procedure = ProcedureResponseDto.builder()
 			.id(1L)
 			.name("레이저 토닝")
-			.worries(Collections.emptyList())
+			.worries(Collections.singletonList(worryResponse(1L, "여드름/트러블")))
 			.minDowntimeDays(0)
 			.maxDowntimeDays(1)
 			.build();
@@ -143,7 +144,7 @@ class ProcedureControllerTest {
 		ProcedureResponseDto procedure = ProcedureResponseDto.builder()
 			.id(2L)
 			.name("프락셀 레이저")
-			.worries(Collections.emptyList())
+			.worries(Collections.singletonList(worryResponse(1L, "여드름/트러블")))
 			.minDowntimeDays(3)
 			.maxDowntimeDays(7)
 			.build();
@@ -160,5 +161,12 @@ class ProcedureControllerTest {
 			.andExpect(jsonPath("$.data.procedures[0].worries").isArray())
 			.andExpect(jsonPath("$.data.procedures[0].minDowntimeDays").value(3))
 			.andExpect(jsonPath("$.data.procedures[0].maxDowntimeDays").value(7));
+	}
+
+	private ProcedureWorryResponseDto worryResponse(Long id, String content) {
+		return ProcedureWorryResponseDto.builder()
+			.id(id)
+			.content(content)
+			.build();
 	}
 }

--- a/src/test/java/com/sopt/cherrish/domain/procedure/presentation/ProcedureControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/procedure/presentation/ProcedureControllerTest.java
@@ -37,7 +37,7 @@ class ProcedureControllerTest {
 		ProcedureResponseDto procedure1 = ProcedureResponseDto.builder()
 			.id(1L)
 			.name("레이저 토닝")
-			.category("레이저")
+			.worries(Collections.emptyList())
 			.minDowntimeDays(0)
 			.maxDowntimeDays(1)
 			.build();
@@ -45,7 +45,7 @@ class ProcedureControllerTest {
 		ProcedureResponseDto procedure2 = ProcedureResponseDto.builder()
 			.id(2L)
 			.name("필러")
-			.category("주사")
+			.worries(Collections.emptyList())
 			.minDowntimeDays(1)
 			.maxDowntimeDays(3)
 			.build();
@@ -72,7 +72,7 @@ class ProcedureControllerTest {
 		ProcedureResponseDto procedure = ProcedureResponseDto.builder()
 			.id(1L)
 			.name("레이저 토닝")
-			.category("레이저")
+			.worries(Collections.emptyList())
 			.minDowntimeDays(0)
 			.maxDowntimeDays(1)
 			.build();
@@ -88,7 +88,7 @@ class ProcedureControllerTest {
 			.andExpect(jsonPath("$.data.procedures").isArray())
 			.andExpect(jsonPath("$.data.procedures.length()").value(1))
 			.andExpect(jsonPath("$.data.procedures[0].name").value("레이저 토닝"))
-			.andExpect(jsonPath("$.data.procedures[0].category").value("레이저"));
+			.andExpect(jsonPath("$.data.procedures[0].worries").isArray());
 	}
 
 	@Test
@@ -100,7 +100,7 @@ class ProcedureControllerTest {
 		ProcedureResponseDto procedure = ProcedureResponseDto.builder()
 			.id(1L)
 			.name("레이저 토닝")
-			.category("레이저")
+			.worries(Collections.emptyList())
 			.minDowntimeDays(0)
 			.maxDowntimeDays(1)
 			.build();
@@ -143,7 +143,7 @@ class ProcedureControllerTest {
 		ProcedureResponseDto procedure = ProcedureResponseDto.builder()
 			.id(2L)
 			.name("프락셀 레이저")
-			.category("레이저")
+			.worries(Collections.emptyList())
 			.minDowntimeDays(3)
 			.maxDowntimeDays(7)
 			.build();
@@ -157,7 +157,7 @@ class ProcedureControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.procedures[0].id").value(2))
 			.andExpect(jsonPath("$.data.procedures[0].name").value("프락셀 레이저"))
-			.andExpect(jsonPath("$.data.procedures[0].category").value("레이저"))
+			.andExpect(jsonPath("$.data.procedures[0].worries").isArray())
 			.andExpect(jsonPath("$.data.procedures[0].minDowntimeDays").value(3))
 			.andExpect(jsonPath("$.data.procedures[0].maxDowntimeDays").value(7));
 	}


### PR DESCRIPTION
# 🛠 Related issue 🛠
- closed #56

# ✏️ Work Description ✏️
- 시술 응답 구조 변경
  - ProcedureResponseDto에 피부 고민 리스트(worries) 포함
  - procedure 도메인 내부 ProcedureWorryResponseDto 추가
- 조회 책임 분리 및 최적화
  - ProcedureWorryRepository 분리 및 fetch join 적용
  - worryId가 있는 경우 해당 worry만 조회하도록 분기
- 서비스/테스트 보강
  - ProcedureService 고민 매핑 로직 반영
  - ProcedureServiceTest, ProcedureControllerTest 응답 변경 사항 반영


# 📸 Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 시술 목록 조회 응답 | <img width="285" height="392" alt="스크린샷 2026-01-13 오전 2 23 01" src="https://github.com/user-attachments/assets/0bd6e7c4-469c-49ec-bb7d-748ca3c5b427" />|

# 😅 Uncompleted Tasks 😅
- 

# 📢 To Reviewers 📢
- 

