### PR TITLE
[Task] success code 분리

### DIFF
--- a/src/main/java/com/sopt/cherrish/domain/challenge/core/presentation/ChallengeLifecycleController.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/core/presentation/ChallengeLifecycleController.java
@@ -10,11 +10,11 @@ import com.sopt.cherrish.domain.challenge.core.application.facade.ChallengeCreat
 import com.sopt.cherrish.domain.challenge.core.exception.ChallengeErrorCode;
 import com.sopt.cherrish.domain.challenge.core.presentation.dto.request.ChallengeCreateRequestDto;
 import com.sopt.cherrish.domain.challenge.core.presentation.dto.response.ChallengeCreateResponseDto;
+import com.sopt.cherrish.domain.challenge.core.response.success.ChallengeSuccessCode;
 import com.sopt.cherrish.domain.user.exception.UserErrorCode;
 import com.sopt.cherrish.global.annotation.ApiExceptions;
 import com.sopt.cherrish.global.response.CommonApiResponse;
 import com.sopt.cherrish.global.response.error.ErrorCode;
-import com.sopt.cherrish.global.response.success.SuccessCode;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -43,6 +43,6 @@ public class ChallengeLifecycleController {
 		@Valid @RequestBody ChallengeCreateRequestDto request
 	) {
 		ChallengeCreateResponseDto response = challengeCreationFacade.createChallenge(userId, request);
-		return CommonApiResponse.success(SuccessCode.SUCCESS, response);
+		return CommonApiResponse.success(ChallengeSuccessCode.CHALLENGE_CREATED, response);
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/challenge/core/presentation/ChallengeQueryController.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/core/presentation/ChallengeQueryController.java
@@ -8,11 +8,11 @@ import org.springframework.web.bind.annotation.RestController;
 import com.sopt.cherrish.domain.challenge.core.application.facade.ChallengeQueryFacade;
 import com.sopt.cherrish.domain.challenge.core.exception.ChallengeErrorCode;
 import com.sopt.cherrish.domain.challenge.core.presentation.dto.response.ChallengeDetailResponseDto;
+import com.sopt.cherrish.domain.challenge.core.response.success.ChallengeSuccessCode;
 import com.sopt.cherrish.domain.user.exception.UserErrorCode;
 import com.sopt.cherrish.global.annotation.ApiExceptions;
 import com.sopt.cherrish.global.response.CommonApiResponse;
 import com.sopt.cherrish.global.response.error.ErrorCode;
-import com.sopt.cherrish.global.response.success.SuccessCode;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -39,6 +39,6 @@ public class ChallengeQueryController {
 		@RequestHeader("X-User-Id") Long userId
 	) {
 		ChallengeDetailResponseDto response = challengeQueryFacade.getActiveChallengeDetail(userId);
-		return CommonApiResponse.success(SuccessCode.SUCCESS, response);
+		return CommonApiResponse.success(ChallengeSuccessCode.CHALLENGE_RETRIEVED, response);
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/challenge/core/presentation/ChallengeRoutineController.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/core/presentation/ChallengeRoutineController.java
@@ -16,11 +16,11 @@ import com.sopt.cherrish.domain.challenge.core.presentation.dto.request.RoutineU
 import com.sopt.cherrish.domain.challenge.core.presentation.dto.response.CustomRoutineAddResponseDto;
 import com.sopt.cherrish.domain.challenge.core.presentation.dto.response.RoutineBatchUpdateResponseDto;
 import com.sopt.cherrish.domain.challenge.core.presentation.dto.response.RoutineCompletionResponseDto;
+import com.sopt.cherrish.domain.challenge.core.response.success.ChallengeSuccessCode;
 import com.sopt.cherrish.domain.user.exception.UserErrorCode;
 import com.sopt.cherrish.global.annotation.ApiExceptions;
 import com.sopt.cherrish.global.response.CommonApiResponse;
 import com.sopt.cherrish.global.response.error.ErrorCode;
-import com.sopt.cherrish.global.response.success.SuccessCode;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -52,7 +52,10 @@ public class ChallengeRoutineController {
 	) {
 		RoutineCompletionResponseDto response =
 			challengeRoutineService.toggleCompletion(userId, routineId);
-		return CommonApiResponse.success(SuccessCode.SUCCESS, response);
+		ChallengeSuccessCode successCode = response.isComplete()
+			? ChallengeSuccessCode.ROUTINE_COMPLETED
+			: ChallengeSuccessCode.ROUTINE_UNCOMPLETED;
+		return CommonApiResponse.success(successCode, response);
 	}
 
 	// TODO: Spring Security 추가 시 RequestHeader userId 제거하고 @AuthenticationPrincipal 사용
@@ -69,7 +72,7 @@ public class ChallengeRoutineController {
 		@Valid @RequestBody RoutineUpdateRequestDto request
 	) {
 		RoutineBatchUpdateResponseDto response = challengeRoutineService.updateMultipleRoutines(userId, request);
-		return CommonApiResponse.success(SuccessCode.SUCCESS, response);
+		return CommonApiResponse.success(ChallengeSuccessCode.ROUTINE_BATCH_UPDATED, response);
 	}
 
 	// TODO: Spring Security 추가 시 RequestHeader userId 제거하고 @AuthenticationPrincipal 사용
@@ -87,6 +90,6 @@ public class ChallengeRoutineController {
 		CustomRoutineAddResponseDto response = challengeCustomRoutineFacade.addCustomRoutine(
 			userId, request
 		);
-		return CommonApiResponse.success(SuccessCode.SUCCESS, response);
+		return CommonApiResponse.success(ChallengeSuccessCode.CUSTOM_ROUTINE_ADDED, response);
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/challenge/core/presentation/dto/response/CustomRoutineAddResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/core/presentation/dto/response/CustomRoutineAddResponseDto.java
@@ -22,10 +22,7 @@ public record CustomRoutineAddResponseDto(
 	List<ChallengeRoutineResponseDto> routines,
 
 	@Schema(description = "업데이트된 총 루틴 개수", example = "26")
-	int totalRoutineCount,
-
-	@Schema(description = "상태 메시지", example = "오늘부터 5일간 '저녁 마사지' 루틴이 추가되었습니다.")
-	String message
+	int totalRoutineCount
 ) {
 	public static CustomRoutineAddResponseDto from(
 		Challenge challenge,
@@ -38,19 +35,13 @@ public record CustomRoutineAddResponseDto(
 			.toList();
 
 		int addedCount = addedRoutines.size();
-		String message = String.format(
-			"오늘부터 %d일간 '%s' 루틴이 추가되었습니다.",
-			addedCount,
-			routineName
-		);
 
 		return new CustomRoutineAddResponseDto(
 			challenge.getId(),
 			routineName,
 			addedCount,
 			routineDtos,
-			totalRoutineCount,
-			message
+			totalRoutineCount
 		);
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/challenge/core/presentation/dto/response/RoutineBatchUpdateResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/core/presentation/dto/response/RoutineBatchUpdateResponseDto.java
@@ -13,10 +13,7 @@ public record RoutineBatchUpdateResponseDto(
 	List<ChallengeRoutineResponseDto> routines,
 
 	@Schema(description = "업데이트된 루틴 개수", example = "3")
-	int updatedCount,
-
-	@Schema(description = "상태 메시지", example = "3개의 루틴이 업데이트되었습니다.")
-	String message
+	int updatedCount
 ) {
 	public static RoutineBatchUpdateResponseDto from(List<ChallengeRoutine> routines) {
 		List<ChallengeRoutineResponseDto> routineDtos = routines.stream()
@@ -24,9 +21,8 @@ public record RoutineBatchUpdateResponseDto(
 			.toList();
 
 		int count = routines.size();
-		String message = count + "개의 루틴이 업데이트되었습니다.";
 
-		return new RoutineBatchUpdateResponseDto(routineDtos, count, message);
+		return new RoutineBatchUpdateResponseDto(routineDtos, count);
 	}
 
 	public static RoutineBatchUpdateResponseDto fromDemoRoutines(List<DemoChallengeRoutine> routines) {
@@ -35,8 +31,7 @@ public record RoutineBatchUpdateResponseDto(
 			.toList();
 
 		int count = routines.size();
-		String message = count + "개의 루틴이 업데이트되었습니다.";
 
-		return new RoutineBatchUpdateResponseDto(routineDtos, count, message);
+		return new RoutineBatchUpdateResponseDto(routineDtos, count);
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/challenge/core/presentation/dto/response/RoutineCompletionResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/core/presentation/dto/response/RoutineCompletionResponseDto.java
@@ -14,34 +14,21 @@ public record RoutineCompletionResponseDto(
 	String name,
 
 	@Schema(description = "완료 여부", example = "true")
-	boolean isComplete,
-
-	@Schema(description = "상태 메시지", example = "루틴을 완료했습니다!")
-	String message
+	boolean isComplete
 ) {
 	public static RoutineCompletionResponseDto from(ChallengeRoutine routine) {
-		String message = routine.getIsComplete()
-			? "루틴을 완료했습니다!"
-			: "루틴 완료를 취소했습니다.";
-
 		return new RoutineCompletionResponseDto(
 			routine.getId(),
 			routine.getName(),
-			routine.getIsComplete(),
-			message
+			routine.getIsComplete()
 		);
 	}
 
 	public static RoutineCompletionResponseDto from(DemoChallengeRoutine routine) {
-		String message = routine.getIsComplete()
-			? "루틴을 완료했습니다!"
-			: "루틴 완료를 취소했습니다.";
-
 		return new RoutineCompletionResponseDto(
 			routine.getId(),
 			routine.getName(),
-			routine.getIsComplete(),
-			message
+			routine.getIsComplete()
 		);
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/challenge/core/response/success/ChallengeSuccessCode.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/core/response/success/ChallengeSuccessCode.java
@@ -15,7 +15,8 @@ public enum ChallengeSuccessCode implements SuccessType {
 	ROUTINE_UNCOMPLETED("CH004", "루틴 완료를 취소했습니다."),
 	ROUTINE_BATCH_UPDATED("CH005", "루틴이 업데이트되었습니다."),
 	CUSTOM_ROUTINE_ADDED("CH006", "커스텀 루틴이 추가되었습니다."),
-	AI_RECOMMENDATION_GENERATED("CH007", "AI 챌린지 추천 생성 성공");
+	AI_RECOMMENDATION_GENERATED("CH007", "AI 챌린지 추천 생성 성공"),
+	HOMECARE_ROUTINES_RETRIEVED("CH008", "홈케어 루틴 목록 조회 성공");
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/sopt/cherrish/domain/challenge/core/response/success/ChallengeSuccessCode.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/core/response/success/ChallengeSuccessCode.java
@@ -1,0 +1,22 @@
+package com.sopt.cherrish.domain.challenge.core.response.success;
+
+import com.sopt.cherrish.global.response.success.SuccessType;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChallengeSuccessCode implements SuccessType {
+	// Challenge 응답 코드 (CH001 ~ CH099)
+	CHALLENGE_CREATED("CH001", "챌린지 생성 성공"),
+	CHALLENGE_RETRIEVED("CH002", "챌린지 조회 성공"),
+	ROUTINE_COMPLETED("CH003", "루틴을 완료했습니다!"),
+	ROUTINE_UNCOMPLETED("CH004", "루틴 완료를 취소했습니다."),
+	ROUTINE_BATCH_UPDATED("CH005", "루틴이 업데이트되었습니다."),
+	CUSTOM_ROUTINE_ADDED("CH006", "커스텀 루틴이 추가되었습니다."),
+	AI_RECOMMENDATION_GENERATED("CH007", "AI 챌린지 추천 생성 성공");
+
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/sopt/cherrish/domain/challenge/demo/application/service/DemoChallengeRoutineService.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/demo/application/service/DemoChallengeRoutineService.java
@@ -100,7 +100,7 @@ public class DemoChallengeRoutineService {
 	private List<DemoChallengeRoutine> fetchAndValidateRoutines(List<Long> routineIds) {
 
 		if (routineIds.isEmpty()) {
-				throw new ChallengeException(ChallengeErrorCode.ROUTINE_NOT_FOUND);
+			throw new ChallengeException(ChallengeErrorCode.ROUTINE_NOT_FOUND);
 		}
 
 		// 중복 ID 검증

--- a/src/main/java/com/sopt/cherrish/domain/challenge/demo/presentation/DemoChallengeController.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/demo/presentation/DemoChallengeController.java
@@ -16,6 +16,7 @@ import com.sopt.cherrish.domain.challenge.core.presentation.dto.response.Challen
 import com.sopt.cherrish.domain.challenge.core.presentation.dto.response.ChallengeDetailResponseDto;
 import com.sopt.cherrish.domain.challenge.core.presentation.dto.response.RoutineBatchUpdateResponseDto;
 import com.sopt.cherrish.domain.challenge.core.presentation.dto.response.RoutineCompletionResponseDto;
+import com.sopt.cherrish.domain.challenge.core.response.success.ChallengeSuccessCode;
 import com.sopt.cherrish.domain.challenge.demo.application.facade.DemoChallengeAdvanceDayFacade;
 import com.sopt.cherrish.domain.challenge.demo.application.facade.DemoChallengeCreationFacade;
 import com.sopt.cherrish.domain.challenge.demo.application.facade.DemoChallengeQueryFacade;
@@ -24,7 +25,6 @@ import com.sopt.cherrish.domain.user.exception.UserErrorCode;
 import com.sopt.cherrish.global.annotation.ApiExceptions;
 import com.sopt.cherrish.global.response.CommonApiResponse;
 import com.sopt.cherrish.global.response.error.ErrorCode;
-import com.sopt.cherrish.global.response.success.SuccessCode;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -55,7 +55,7 @@ public class DemoChallengeController {
 		@Valid @RequestBody ChallengeCreateRequestDto request
 	) {
 		ChallengeCreateResponseDto response = creationFacade.createChallenge(userId, request);
-		return CommonApiResponse.success(SuccessCode.SUCCESS, response);
+		return CommonApiResponse.success(ChallengeSuccessCode.CHALLENGE_CREATED, response);
 	}
 
 	@Operation(
@@ -69,7 +69,7 @@ public class DemoChallengeController {
 		@RequestHeader("X-User-Id") Long userId
 	) {
 		ChallengeDetailResponseDto response = queryFacade.getActiveChallengeDetail(userId);
-		return CommonApiResponse.success(SuccessCode.SUCCESS, response);
+		return CommonApiResponse.success(ChallengeSuccessCode.CHALLENGE_RETRIEVED, response);
 	}
 
 	@Operation(
@@ -83,7 +83,7 @@ public class DemoChallengeController {
 		@RequestHeader("X-User-Id") Long userId
 	) {
 		ChallengeDetailResponseDto response = advanceDayFacade.advanceDay(userId);
-		return CommonApiResponse.success(SuccessCode.SUCCESS, response);
+		return CommonApiResponse.success(ChallengeSuccessCode.CHALLENGE_RETRIEVED, response);
 	}
 
 	@Operation(
@@ -100,7 +100,10 @@ public class DemoChallengeController {
 		@PathVariable Long routineId
 	) {
 		RoutineCompletionResponseDto response = routineService.toggleCompletion(userId, routineId);
-		return CommonApiResponse.success(SuccessCode.SUCCESS, response);
+		ChallengeSuccessCode successCode = response.isComplete()
+			? ChallengeSuccessCode.ROUTINE_COMPLETED
+			: ChallengeSuccessCode.ROUTINE_UNCOMPLETED;
+		return CommonApiResponse.success(successCode, response);
 	}
 
 	@Operation(
@@ -117,6 +120,6 @@ public class DemoChallengeController {
 		@Valid @RequestBody RoutineUpdateRequestDto request
 	) {
 		RoutineBatchUpdateResponseDto response = routineService.updateMultipleRoutines(userId, request);
-		return CommonApiResponse.success(SuccessCode.SUCCESS, response);
+		return CommonApiResponse.success(ChallengeSuccessCode.ROUTINE_BATCH_UPDATED, response);
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/challenge/homecare/presentation/HomecareRoutineController.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/homecare/presentation/HomecareRoutineController.java
@@ -6,10 +6,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.sopt.cherrish.domain.challenge.core.response.success.ChallengeSuccessCode;
 import com.sopt.cherrish.domain.challenge.homecare.application.service.HomecareRoutineService;
 import com.sopt.cherrish.domain.challenge.homecare.presentation.dto.response.HomecareRoutineResponseDto;
 import com.sopt.cherrish.global.response.CommonApiResponse;
-import com.sopt.cherrish.global.response.success.SuccessCode;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -30,6 +30,6 @@ public class HomecareRoutineController {
 	@GetMapping("/homecare-routines")
 	public CommonApiResponse<List<HomecareRoutineResponseDto>> getHomecareRoutines() {
 		List<HomecareRoutineResponseDto> routines = homecareRoutineService.getAllHomecareRoutines();
-		return CommonApiResponse.success(SuccessCode.SUCCESS, routines);
+		return CommonApiResponse.success(ChallengeSuccessCode.HOMECARE_ROUTINES_RETRIEVED, routines);
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/challenge/recommendation/presentation/ChallengeRecommendationController.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/recommendation/presentation/ChallengeRecommendationController.java
@@ -7,13 +7,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.sopt.cherrish.domain.ai.exception.AiErrorCode;
 import com.sopt.cherrish.domain.challenge.core.exception.ChallengeErrorCode;
+import com.sopt.cherrish.domain.challenge.core.response.success.ChallengeSuccessCode;
 import com.sopt.cherrish.domain.challenge.recommendation.application.service.AiChallengeRecommendationService;
 import com.sopt.cherrish.domain.challenge.recommendation.presentation.dto.request.AiRecommendationRequestDto;
 import com.sopt.cherrish.domain.challenge.recommendation.presentation.dto.response.AiRecommendationResponseDto;
 import com.sopt.cherrish.global.annotation.ApiExceptions;
 import com.sopt.cherrish.global.response.CommonApiResponse;
 import com.sopt.cherrish.global.response.error.ErrorCode;
-import com.sopt.cherrish.global.response.success.SuccessCode;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -39,6 +39,6 @@ public class ChallengeRecommendationController {
 	) {
 		AiRecommendationResponseDto response = aiRecommendationService.generateRecommendation(
 			request.homecareRoutineId());
-		return CommonApiResponse.success(SuccessCode.SUCCESS, response);
+		return CommonApiResponse.success(ChallengeSuccessCode.AI_RECOMMENDATION_GENERATED, response);
 	}
 }

--- a/src/test/java/com/sopt/cherrish/domain/challenge/core/application/facade/ChallengeCustomRoutineFacadeIntegrationTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/challenge/core/application/facade/ChallengeCustomRoutineFacadeIntegrationTest.java
@@ -129,7 +129,6 @@ class ChallengeCustomRoutineFacadeIntegrationTest {
 		assertThat(response.addedCount()).isEqualTo(7); // 2024-01-01 ~ 2024-01-07 = 7일
 		assertThat(response.routines()).hasSize(7);
 		assertThat(response.totalRoutineCount()).isEqualTo(28); // 기존 21 + 추가 7 = 28
-		assertThat(response.message()).contains("7일간");
 
 		// then - DB 실제 저장 확인
 		List<ChallengeRoutine> allRoutines = routineRepository.findAll();

--- a/src/test/java/com/sopt/cherrish/domain/challenge/core/fixture/ChallengeTestFixture.java
+++ b/src/test/java/com/sopt/cherrish/domain/challenge/core/fixture/ChallengeTestFixture.java
@@ -158,8 +158,7 @@ public class ChallengeTestFixture {
 		return new RoutineCompletionResponseDto(
 			DEFAULT_ROUTINE_ID,
 			DEFAULT_ROUTINE_NAME,
-			isComplete,
-			createRoutineCompletionMessage(isComplete)
+			isComplete
 		);
 	}
 
@@ -224,7 +223,7 @@ public class ChallengeTestFixture {
 			new ChallengeRoutineResponseDto(3L, "크림 바르기", FIXED_START_DATE, true)
 		);
 
-		return new RoutineBatchUpdateResponseDto(routines, 3, createRoutineBatchUpdateMessage(3));
+		return new RoutineBatchUpdateResponseDto(routines, 3);
 	}
 
 	/**
@@ -235,7 +234,7 @@ public class ChallengeTestFixture {
 			new ChallengeRoutineResponseDto(1L, "아침 세안", FIXED_START_DATE, true)
 		);
 
-		return new RoutineBatchUpdateResponseDto(routines, 1, createRoutineBatchUpdateMessage(1));
+		return new RoutineBatchUpdateResponseDto(routines, 1);
 	}
 
 	/**


### PR DESCRIPTION
# 🛠 Related issue 🛠
  - closed #62

  # ✏️ Work Description ✏️
  - **ChallengeSuccessCode 생성**
      - Challenge 도메인 전용 성공 코드 분리 (CH001 ~ CH099)
      - ErrorCode처럼 도메인별로 성공 코드 관리
      - 8개의 성공 코드 정의: 챌린지 생성/조회, 루틴 완료/취소, 일괄 업데이트, 커스텀 루틴 추가, AI 추천, 홈케어 루틴 조회

  - **ResponseDto 중복 메시지 제거**
      - `RoutineCompletionResponseDto` - message 필드 제거
      - `RoutineBatchUpdateResponseDto` - message 필드 제거
      - `CustomRoutineAddResponseDto` - message 필드 제거
      - CommonApiResponse의 message와 data.message 중복 해소

  - **Controller 적용**
      - `ChallengeLifecycleController` - CHALLENGE_CREATED
      - `ChallengeQueryController` - CHALLENGE_RETRIEVED
      - `ChallengeRoutineController` - 상태에 따라 ROUTINE_COMPLETED/ROUTINE_UNCOMPLETED, ROUTINE_BATCH_UPDATED, CUSTOM_ROUTINE_ADDED
      - `ChallengeRecommendationController` - AI_RECOMMENDATION_GENERATED
      - `HomecareRoutineController` - HOMECARE_ROUTINES_RETRIEVED
      - `DemoChallengeController` - 모든 성공 코드 적용

  - **테스트 코드 수정**
      - `ChallengeTestFixture` - ResponseDto 생성 시 message 파라미터 제거
      - `ChallengeCustomRoutineFacadeIntegrationTest` - message 필드 검증 제거

  # 📸 Screenshot 📸
  ## 변경 전
  ```json
  {
    "code": "S200",
    "message": "성공",
    "data": {
      "routineId": 1,
      "name": "아침 세안",
      "isComplete": true,
      "message": "루틴을 완료했습니다!"
    }
  }
```

  변경 후

  ```json
  {
    "code": "CH003",
    "message": "루틴을 완료했습니다!",
    "data": {
      "routineId": 1,
      "name": "아침 세안",
      "isComplete": true                                                                                                                                                                                 
    }
  }
```

  😅 Uncompleted Tasks 😅

  - 없음

  📢 To Reviewers 📢
  - 기존의 Success Code를 중앙화해서 관리하는 아이디어는 swagger annotation을 사용함에 있어서 어쩔 수 없는 제약이었는데 관련 코드를 정리하면서(#23 ) 제약이 사라지게 된 배경이 있습니다.
  - Challenge에서 응답 코드를 자세하게 보내줘야 하는 케이스가 생겼고(루틴 완료 토글 on/off 등) 이는 도메인별로 따로 관리하는게 맞다고 생각했습니다. 그래서 기존 컨벤션인 SuccessCode 필요에 따라 도메인내에 만들어서 관리하는 걸로 바꾸면 어떨까 합니다.
  - ChallengeSuccessCode 위치: core/response/success에 배치했는데, 더 적절한 위치가 있다면 제안 부탁드립니다.
  - 성공 코드 네이밍: CH001~CH099로 할당했는데 컨벤션 확인 부탁드립니다.
  - 루틴 완료 토글 로직: isComplete 상태에 따라 동적으로 SuccessCode를 선택하는 로직이 Controller에 있는데 UseCase보다는 api 응답을 꾸며 주기 위한 로직으로써 presentation Layer가 맞다고 생각했습니다. 