### PR TITLE
[Enhancement] 날짜별 시술 조회와 다운타임 상세 조회 분리

### DIFF
--- a/src/main/java/com/sopt/cherrish/domain/calendar/application/service/CalendarService.java
+++ b/src/main/java/com/sopt/cherrish/domain/calendar/application/service/CalendarService.java
@@ -80,7 +80,7 @@ public class CalendarService {
 
 		// 시술 일정 단건 조회
 		UserProcedure userProcedure = userProcedureRepository
-			.findByIdAndUserIdWithProcedure(userProcedureId, userId)
+			.findByIdAndUserId(userProcedureId, userId)
 			.orElseThrow(() -> new UserProcedureException(UserProcedureErrorCode.USER_PROCEDURE_NOT_FOUND));
 
 		return ProcedureEventDowntimeResponseDto.from(userProcedure);

--- a/src/main/java/com/sopt/cherrish/domain/calendar/presentation/CalendarController.java
+++ b/src/main/java/com/sopt/cherrish/domain/calendar/presentation/CalendarController.java
@@ -2,6 +2,7 @@ package com.sopt.cherrish.domain.calendar.presentation;
 
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,7 +13,9 @@ import com.sopt.cherrish.domain.calendar.presentation.dto.request.CalendarDailyR
 import com.sopt.cherrish.domain.calendar.presentation.dto.request.CalendarMonthlyRequestDto;
 import com.sopt.cherrish.domain.calendar.presentation.dto.response.CalendarDailyResponseDto;
 import com.sopt.cherrish.domain.calendar.presentation.dto.response.CalendarMonthlyResponseDto;
+import com.sopt.cherrish.domain.calendar.presentation.dto.response.ProcedureEventDowntimeResponseDto;
 import com.sopt.cherrish.domain.user.exception.UserErrorCode;
+import com.sopt.cherrish.domain.userprocedure.exception.UserProcedureErrorCode;
 import com.sopt.cherrish.global.annotation.ApiExceptions;
 import com.sopt.cherrish.global.response.CommonApiResponse;
 import com.sopt.cherrish.global.response.error.ErrorCode;
@@ -22,6 +25,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -54,7 +58,7 @@ public class CalendarController {
 
 	@Operation(
 		summary = "일자별 시술 상세 조회",
-		description = "특정 날짜의 시술 목록과 다운타임 기간(민감기/주의기/회복기)을 조회합니다."
+		description = "특정 날짜의 시술 목록을 조회합니다."
 	)
 	@ApiExceptions({UserErrorCode.class, ErrorCode.class})
 	@GetMapping("/daily")
@@ -64,6 +68,22 @@ public class CalendarController {
 		@Valid @ModelAttribute CalendarDailyRequestDto request
 	) {
 		CalendarDailyResponseDto response = calendarService.getDailyCalendar(userId, request.date());
+		return CommonApiResponse.success(SuccessCode.SUCCESS, response);
+	}
+
+	@Operation(
+		summary = "시술 다운타임 상세 조회",
+		description = "특정 시술 일정의 다운타임 기간(민감기/주의기/회복기)을 조회합니다."
+	)
+	@ApiExceptions({UserErrorCode.class, UserProcedureErrorCode.class, ErrorCode.class})
+	@GetMapping("/events/{id}/downtime")
+	public CommonApiResponse<ProcedureEventDowntimeResponseDto> getEventDowntime(
+		@Parameter(description = "사용자 ID (X-User-Id 헤더)", required = true, example = "1")
+		@RequestHeader("X-User-Id") Long userId,
+		@Parameter(description = "사용자 시술 일정 ID", required = true, example = "123")
+		@PathVariable("id") @Positive Long userProcedureId
+	) {
+		ProcedureEventDowntimeResponseDto response = calendarService.getEventDowntime(userId, userProcedureId);
 		return CommonApiResponse.success(SuccessCode.SUCCESS, response);
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/calendar/presentation/dto/response/ProcedureEventDowntimeResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/calendar/presentation/dto/response/ProcedureEventDowntimeResponseDto.java
@@ -1,0 +1,57 @@
+package com.sopt.cherrish.domain.calendar.presentation.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
+import com.sopt.cherrish.domain.userprocedure.domain.vo.DowntimePeriod;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "시술 다운타임 상세")
+public class ProcedureEventDowntimeResponseDto {
+
+	@Schema(description = "사용자 시술 일정 ID", example = "123")
+	private Long userProcedureId;
+
+	@Schema(description = "예약 날짜 및 시간", example = "2026-01-15T14:00:00")
+	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+	private LocalDateTime scheduledAt;
+
+	@Schema(description = "다운타임(일)", example = "7")
+	private Integer downtimeDays;
+
+	@Schema(description = "민감기 날짜 목록", example = "[\"2026-01-15\", \"2026-01-16\", \"2026-01-17\"]")
+	@JsonSerialize(contentUsing = LocalDateSerializer.class)
+	private List<LocalDate> sensitiveDays;
+
+	@Schema(description = "주의기 날짜 목록", example = "[\"2026-01-18\", \"2026-01-19\"]")
+	@JsonSerialize(contentUsing = LocalDateSerializer.class)
+	private List<LocalDate> cautionDays;
+
+	@Schema(description = "회복기 날짜 목록", example = "[\"2026-01-20\", \"2026-01-21\"]")
+	@JsonSerialize(contentUsing = LocalDateSerializer.class)
+	private List<LocalDate> recoveryDays;
+
+	public static ProcedureEventDowntimeResponseDto from(UserProcedure userProcedure) {
+		// Entity로부터 다운타임 기간 계산
+		DowntimePeriod downtimePeriod = userProcedure.calculateDowntimePeriod();
+
+		return ProcedureEventDowntimeResponseDto.builder()
+			.userProcedureId(userProcedure.getId())
+			.scheduledAt(userProcedure.getScheduledAt())
+			.downtimeDays(userProcedure.getDowntimeDays())
+			.sensitiveDays(downtimePeriod.getSensitiveDays())
+			.cautionDays(downtimePeriod.getCautionDays())
+			.recoveryDays(downtimePeriod.getRecoveryDays())
+			.build();
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/calendar/presentation/dto/response/ProcedureEventResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/calendar/presentation/dto/response/ProcedureEventResponseDto.java
@@ -1,15 +1,10 @@
 package com.sopt.cherrish.domain.calendar.presentation.dto.response;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 import com.sopt.cherrish.domain.calendar.domain.model.CalendarEventType;
 import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
-import com.sopt.cherrish.domain.userprocedure.domain.vo.DowntimePeriod;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -24,7 +19,7 @@ public class ProcedureEventResponseDto {
 	private CalendarEventType type;
 
 	@Schema(description = "사용자 시술 일정 ID", example = "123")
-	private Long id;
+	private Long userProcedureId;
 
 	@Schema(description = "시술 ID", example = "5")
 	private Long procedureId;
@@ -39,32 +34,14 @@ public class ProcedureEventResponseDto {
 	@Schema(description = "다운타임(일)", example = "7")
 	private Integer downtimeDays;
 
-	@Schema(description = "민감기 날짜 목록", example = "[\"2026-01-15\", \"2026-01-16\", \"2026-01-17\"]")
-	@JsonSerialize(contentUsing = LocalDateSerializer.class)
-	private List<LocalDate> sensitiveDays;
-
-	@Schema(description = "주의기 날짜 목록", example = "[\"2026-01-18\", \"2026-01-19\"]")
-	@JsonSerialize(contentUsing = LocalDateSerializer.class)
-	private List<LocalDate> cautionDays;
-
-	@Schema(description = "회복기 날짜 목록", example = "[\"2026-01-20\", \"2026-01-21\"]")
-	@JsonSerialize(contentUsing = LocalDateSerializer.class)
-	private List<LocalDate> recoveryDays;
-
 	public static ProcedureEventResponseDto from(UserProcedure userProcedure) {
-		// Entity로부터 다운타임 기간 계산 (비즈니스 로직은 Entity에서 처리)
-		DowntimePeriod downtimePeriod = userProcedure.calculateDowntimePeriod();
-
 		return ProcedureEventResponseDto.builder()
 			.type(CalendarEventType.PROCEDURE)
-			.id(userProcedure.getId())
+			.userProcedureId(userProcedure.getId())
 			.procedureId(userProcedure.getProcedure().getId())
 			.name(userProcedure.getProcedure().getName())
 			.scheduledAt(userProcedure.getScheduledAt())
 			.downtimeDays(userProcedure.getDowntimeDays())
-			.sensitiveDays(downtimePeriod.getSensitiveDays())
-			.cautionDays(downtimePeriod.getCautionDays())
-			.recoveryDays(downtimePeriod.getRecoveryDays())
 			.build();
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepository.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepository.java
@@ -3,17 +3,11 @@ package com.sopt.cherrish.domain.userprocedure.domain.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
 
 public interface UserProcedureRepository extends JpaRepository<UserProcedure, Long>,
 	UserProcedureRepositoryCustom {
 
-	@Query("SELECT up FROM UserProcedure up WHERE up.id = :userProcedureId AND up.user.id = :userId")
-	Optional<UserProcedure> findByIdAndUserId(
-		@Param("userProcedureId") Long userProcedureId,
-		@Param("userId") Long userId
-	);
+	Optional<UserProcedure> findByIdAndUserId(Long userProcedureId, Long userId);
 }

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepository.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepository.java
@@ -11,8 +11,8 @@ import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
 public interface UserProcedureRepository extends JpaRepository<UserProcedure, Long>,
 	UserProcedureRepositoryCustom {
 
-	@Query("SELECT up FROM UserProcedure up JOIN FETCH up.procedure WHERE up.id = :userProcedureId AND up.user.id = :userId")
-	Optional<UserProcedure> findByIdAndUserIdWithProcedure(
+	@Query("SELECT up FROM UserProcedure up WHERE up.id = :userProcedureId AND up.user.id = :userId")
+	Optional<UserProcedure> findByIdAndUserId(
 		@Param("userProcedureId") Long userProcedureId,
 		@Param("userId") Long userId
 	);

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepository.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepository.java
@@ -1,9 +1,19 @@
 package com.sopt.cherrish.domain.userprocedure.domain.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
 
 public interface UserProcedureRepository extends JpaRepository<UserProcedure, Long>,
 	UserProcedureRepositoryCustom {
+
+	@Query("SELECT up FROM UserProcedure up JOIN FETCH up.procedure WHERE up.id = :userProcedureId AND up.user.id = :userId")
+	Optional<UserProcedure> findByIdAndUserIdWithProcedure(
+		@Param("userProcedureId") Long userProcedureId,
+		@Param("userId") Long userId
+	);
 }

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryImpl.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryImpl.java
@@ -58,7 +58,7 @@ public class UserProcedureRepositoryImpl implements UserProcedureRepositoryCusto
 				userProcedure.scheduledAt.goe(startOfDay),
 				userProcedure.scheduledAt.lt(endOfDay)
 			)
-			.orderBy(userProcedure.scheduledAt.asc())
+			.orderBy(userProcedure.createdAt.desc())
 			.fetch();
 	}
 

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/exception/UserProcedureErrorCode.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/exception/UserProcedureErrorCode.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum UserProcedureErrorCode implements ErrorType {
 	// UserProcedure 도메인 에러 (UP001 ~ UP099)
-	INVALID_DOWNTIME_DAYS("UP001", "다운타임 일수는 0일 이상 30일 이하여야 합니다", 400);
+	INVALID_DOWNTIME_DAYS("UP001", "다운타임 일수는 0일 이상 30일 이하여야 합니다", 400),
+	USER_PROCEDURE_NOT_FOUND("UP002", "시술 일정을 찾을 수 없습니다", 404);
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/sopt/cherrish/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sopt/cherrish/global/exception/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
@@ -21,6 +22,7 @@ import com.sopt.cherrish.global.response.CommonApiResponse;
 import com.sopt.cherrish.global.response.error.ErrorCode;
 import com.sopt.cherrish.global.response.error.ErrorType;
 
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -51,6 +53,14 @@ public class GlobalExceptionHandler {
 			));
 		log.warn("Validation failed: {}", errors);
 		return CommonApiResponse.fail(ErrorCode.INVALID_INPUT, errors);
+	}
+
+	// 메서드 파라미터 검증 실패 처리 (@PathVariable, @RequestParam 등)
+	@ExceptionHandler({ConstraintViolationException.class, HandlerMethodValidationException.class})
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	public CommonApiResponse<Void> handleMethodValidationException(Exception e) {
+		log.warn("Method validation failed: {}", e.getMessage());
+		return CommonApiResponse.fail(ErrorCode.INVALID_INPUT);
 	}
 
 	// 필수 요청 헤더 누락 처리

--- a/src/test/java/com/sopt/cherrish/domain/calendar/application/service/CalendarServiceTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/calendar/application/service/CalendarServiceTest.java
@@ -173,7 +173,7 @@ class CalendarServiceTest {
 			mockUser, mockProcedure, LocalDateTime.of(2025, 1, 15, 14, 0), downtimeDays);
 
 		given(userRepository.existsById(userId)).willReturn(true);
-		given(userProcedureRepository.findByIdAndUserIdWithProcedure(userProcedureId, userId))
+		given(userProcedureRepository.findByIdAndUserId(userProcedureId, userId))
 			.willReturn(Optional.of(userProcedure));
 
 		// when
@@ -209,7 +209,7 @@ class CalendarServiceTest {
 		Long userProcedureId = 404L;
 
 		given(userRepository.existsById(userId)).willReturn(true);
-		given(userProcedureRepository.findByIdAndUserIdWithProcedure(userProcedureId, userId))
+		given(userProcedureRepository.findByIdAndUserId(userProcedureId, userId))
 			.willReturn(Optional.empty());
 
 		// when & then

--- a/src/test/java/com/sopt/cherrish/domain/calendar/fixture/CalendarTestFixture.java
+++ b/src/test/java/com/sopt/cherrish/domain/calendar/fixture/CalendarTestFixture.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import com.sopt.cherrish.domain.calendar.domain.model.CalendarEventType;
 import com.sopt.cherrish.domain.calendar.presentation.dto.response.CalendarDailyResponseDto;
+import com.sopt.cherrish.domain.calendar.presentation.dto.response.ProcedureEventDowntimeResponseDto;
 import com.sopt.cherrish.domain.calendar.presentation.dto.response.ProcedureEventResponseDto;
 import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
 import com.sopt.cherrish.domain.user.domain.model.User;
@@ -44,27 +45,39 @@ public class CalendarTestFixture {
 	}
 
 	public static CalendarDailyResponseDto createDailyResponseWithSingleEvent(
-		Long eventId,
+		Long userProcedureId,
 		Long procedureId,
 		String procedureName,
+		LocalDateTime scheduledAt,
+		int downtimeDays
+	) {
+		ProcedureEventResponseDto event = ProcedureEventResponseDto.builder()
+			.type(CalendarEventType.PROCEDURE)
+			.userProcedureId(userProcedureId)
+			.procedureId(procedureId)
+			.name(procedureName)
+			.scheduledAt(scheduledAt)
+			.downtimeDays(downtimeDays)
+			.build();
+
+		return CalendarDailyResponseDto.from(List.of(event));
+	}
+
+	public static ProcedureEventDowntimeResponseDto createDowntimeResponse(
+		Long userProcedureId,
 		LocalDateTime scheduledAt,
 		int downtimeDays,
 		List<LocalDate> sensitiveDays,
 		List<LocalDate> cautionDays,
 		List<LocalDate> recoveryDays
 	) {
-		ProcedureEventResponseDto event = ProcedureEventResponseDto.builder()
-			.type(CalendarEventType.PROCEDURE)
-			.id(eventId)
-			.procedureId(procedureId)
-			.name(procedureName)
+		return ProcedureEventDowntimeResponseDto.builder()
+			.userProcedureId(userProcedureId)
 			.scheduledAt(scheduledAt)
 			.downtimeDays(downtimeDays)
 			.sensitiveDays(sensitiveDays)
 			.cautionDays(cautionDays)
 			.recoveryDays(recoveryDays)
 			.build();
-
-		return CalendarDailyResponseDto.from(List.of(event));
 	}
 }

--- a/src/test/java/com/sopt/cherrish/domain/calendar/presentation/CalendarControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/calendar/presentation/CalendarControllerTest.java
@@ -14,6 +14,8 @@ import java.util.Map;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -186,6 +188,15 @@ class CalendarControllerTest {
 			.andExpect(jsonPath("$.data.cautionDays").isArray())
 			.andExpect(jsonPath("$.data.cautionDays.length()").value(3))
 			.andExpect(jsonPath("$.data.recoveryDays").isArray())
-			.andExpect(jsonPath("$.data.recoveryDays.length()").value(3));
+		.andExpect(jsonPath("$.data.recoveryDays.length()").value(3));
+	}
+
+	@ParameterizedTest
+	@ValueSource(longs = {0L, -1L})
+	@DisplayName("시술 다운타임 상세 조회 실패 - 잘못된 사용자 시술 일정 ID")
+	void getEventDowntimeInvalidId(long userProcedureId) throws Exception {
+		mockMvc.perform(get("/api/calendar/events/{id}/downtime", userProcedureId)
+				.header("X-User-Id", 1L))
+			.andExpect(status().isBadRequest());
 	}
 }

--- a/src/test/java/com/sopt/cherrish/domain/calendar/presentation/CalendarControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/calendar/presentation/CalendarControllerTest.java
@@ -188,7 +188,7 @@ class CalendarControllerTest {
 			.andExpect(jsonPath("$.data.cautionDays").isArray())
 			.andExpect(jsonPath("$.data.cautionDays.length()").value(3))
 			.andExpect(jsonPath("$.data.recoveryDays").isArray())
-		.andExpect(jsonPath("$.data.recoveryDays.length()").value(3));
+		    .andExpect(jsonPath("$.data.recoveryDays.length()").value(3));
 	}
 
 	@ParameterizedTest

--- a/src/test/java/com/sopt/cherrish/domain/calendar/presentation/CalendarControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/calendar/presentation/CalendarControllerTest.java
@@ -188,7 +188,7 @@ class CalendarControllerTest {
 			.andExpect(jsonPath("$.data.cautionDays").isArray())
 			.andExpect(jsonPath("$.data.cautionDays.length()").value(3))
 			.andExpect(jsonPath("$.data.recoveryDays").isArray())
-		    .andExpect(jsonPath("$.data.recoveryDays.length()").value(3));
+			.andExpect(jsonPath("$.data.recoveryDays.length()").value(3));
 	}
 
 	@ParameterizedTest


### PR DESCRIPTION
# 🛠 Related issue 🛠
- closed #61 

# ✏️ Work Description ✏️
- 캘린더 일자별 조회/시술 다운타임 상세 조회 분리
   - /api/calendar/daily는 요약 필드만 반환, /api/calendar/events/{id}/downtime에서 기간 상세 반환
   - DTO 분리: ProcedureEventResponseDto(시술 리스트) / ProcedureEventDowntimeResponseDto(특정 시술 다운타임 상세)
- 조회 정렬 및 조회 로직 보강
    - 일자별 조회 정렬을 createdAt 내림차순으로 변경
    - 다운타임 조회용 쿼리에서 불필요한 fetch join 제거
- 검증/예외 처리 및 테스트 정리
    - @Positive PathVariable 검증 및 GlobalExceptionHandler 메서드 파라미터 검증 예외 처리
    - 캘린더 관련 테스트/fixture 리팩터링, 다운타임 검증 테스트 추가

# 📸 Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 일자별 시술 상세 조회| <img width="341" height="395" alt="스크린샷 2026-01-13 오후 5 04 18" src="https://github.com/user-attachments/assets/d2743685-7192-4f7e-a69c-feaf84d96897" /> |
| 시술 다운타임 상세 조회 | <img width="305" height="353" alt="스크린샷 2026-01-13 오후 5 06 27" src="https://github.com/user-attachments/assets/78d59b55-7000-4ba4-ae03-6b5c4e420fc7" />|
| userProcedureId 입력값 올바르지 않은 경우 (ex)0,-1) |<img width="265" height="81" alt="스크린샷 2026-01-13 오후 5 05 34" src="https://github.com/user-attachments/assets/a78c387c-1661-448c-8914-e2a98599b172" />|

# 😅 Uncompleted Tasks 😅
- 

# 📢 To Reviewers 📢
 - 다운타임 상세에서 @Positive 검증과 에러 응답 확인 부탁드립니다

