### PR TITLE
[Feature] 마이 탭 사용자 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/sopt/cherrish/domain/user/application/service/UserService.java
+++ b/src/main/java/com/sopt/cherrish/domain/user/application/service/UserService.java
@@ -1,5 +1,9 @@
 package com.sopt.cherrish.domain.user.application.service;
 
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -9,6 +13,7 @@ import com.sopt.cherrish.domain.user.exception.UserErrorCode;
 import com.sopt.cherrish.domain.user.exception.UserException;
 import com.sopt.cherrish.domain.user.presentation.dto.request.UserUpdateRequestDto;
 import com.sopt.cherrish.domain.user.presentation.dto.response.UserResponseDto;
+import com.sopt.cherrish.domain.user.presentation.dto.response.UserSummaryResponseDto;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 public class UserService {
 
 	private final UserRepository userRepository;
+	private final Clock clock;
 
 	/**
 	 * 사용자 존재 여부 검증
@@ -35,13 +41,18 @@ public class UserService {
 	 * 사용자 조회
 	 *
 	 * @param id 사용자 ID
-	 * @return 사용자 정보
+	 * @return 사용자 요약 정보
 	 * @throws UserException 사용자를 찾을 수 없는 경우
 	 */
-	public UserResponseDto getUser(Long id) {
+	public UserSummaryResponseDto getUser(Long id) {
 		User user = userRepository.findById(id)
 			.orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
-		return UserResponseDto.from(user);
+		LocalDate today = LocalDate.now(clock);
+		int daysSinceSignup = (int) ChronoUnit.DAYS.between(
+			user.getCreatedAt().toLocalDate(),
+			today
+		) + 1;
+		return UserSummaryResponseDto.from(user, daysSinceSignup);
 	}
 
 	/**

--- a/src/main/java/com/sopt/cherrish/domain/user/presentation/UserController.java
+++ b/src/main/java/com/sopt/cherrish/domain/user/presentation/UserController.java
@@ -12,6 +12,7 @@ import com.sopt.cherrish.domain.user.application.service.UserService;
 import com.sopt.cherrish.domain.user.exception.UserErrorCode;
 import com.sopt.cherrish.domain.user.presentation.dto.request.UserUpdateRequestDto;
 import com.sopt.cherrish.domain.user.presentation.dto.response.UserResponseDto;
+import com.sopt.cherrish.domain.user.presentation.dto.response.UserSummaryResponseDto;
 import com.sopt.cherrish.global.annotation.ApiExceptions;
 import com.sopt.cherrish.global.response.CommonApiResponse;
 import com.sopt.cherrish.global.response.error.ErrorCode;
@@ -33,15 +34,15 @@ public class UserController {
 
 	@Operation(
 		summary = "사용자 조회",
-		description = "사용자 ID로 사용자 정보를 조회합니다."
+		description = "사용자 이름과 회원가입 경과일을 조회합니다."
 	)
 	@ApiExceptions({UserErrorCode.class, ErrorCode.class})
 	@GetMapping
-	public CommonApiResponse<UserResponseDto> getUser(
+	public CommonApiResponse<UserSummaryResponseDto> getUser(
 		@Parameter(description = "사용자 ID (X-User-Id 헤더)", required = true, example = "1")
 		@RequestHeader("X-User-Id") Long userId
 	) {
-		UserResponseDto response = userService.getUser(userId);
+		UserSummaryResponseDto response = userService.getUser(userId);
 		return CommonApiResponse.success(SuccessCode.SUCCESS, response);
 	}
 

--- a/src/main/java/com/sopt/cherrish/domain/user/presentation/dto/response/UserSummaryResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/user/presentation/dto/response/UserSummaryResponseDto.java
@@ -1,0 +1,26 @@
+package com.sopt.cherrish.domain.user.presentation.dto.response;
+
+import com.sopt.cherrish.domain.user.domain.model.User;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "사용자 요약 정보 응답")
+public class UserSummaryResponseDto {
+
+	@Schema(description = "사용자 이름", example = "홍길동")
+	private String name;
+
+	@Schema(description = "회원가입 경과일 (가입 당일 = 1일차)", example = "3")
+	private Integer daysSinceSignup;
+
+	public static UserSummaryResponseDto from(User user, int daysSinceSignup) {
+		return UserSummaryResponseDto.builder()
+			.name(user.getName())
+			.daysSinceSignup(daysSinceSignup)
+			.build();
+	}
+}

--- a/src/test/java/com/sopt/cherrish/domain/user/application/service/UserServiceTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/user/application/service/UserServiceTest.java
@@ -87,6 +87,31 @@ class UserServiceTest {
 	}
 
 	@Test
+	@DisplayName("사용자 조회 성공 - 자정 경계 일차 계산")
+	void getUserSuccessWithMidnightBoundary() {
+		// given
+		Long userId = 1L;
+		LocalDateTime createdAt = LocalDateTime.of(2026, 1, 1, 23, 59, 59);
+		User user = UserFixture.createUser("홍길동", 25, createdAt);
+		ZoneId zoneId = ZoneId.of("Asia/Seoul");
+		Instant fixedInstant = LocalDateTime.of(2026, 1, 2, 0, 0, 1)
+			.atZone(zoneId)
+			.toInstant();
+
+		given(userRepository.findById(userId)).willReturn(Optional.of(user));
+		given(clock.getZone()).willReturn(zoneId);
+		given(clock.instant()).willReturn(fixedInstant);
+
+		// when
+		UserSummaryResponseDto result = userService.getUser(userId);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getName()).isEqualTo("홍길동");
+		assertThat(result.getDaysSinceSignup()).isEqualTo(2);
+	}
+
+	@Test
 	@DisplayName("사용자 조회 실패 - 존재하지 않는 사용자")
 	void getUserNotFound() {
 		// given

--- a/src/test/java/com/sopt/cherrish/domain/user/application/service/UserServiceTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/user/application/service/UserServiceTest.java
@@ -6,6 +6,9 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.times;
 import static org.mockito.BDDMockito.verify;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -22,6 +25,7 @@ import com.sopt.cherrish.domain.user.exception.UserException;
 import com.sopt.cherrish.domain.user.fixture.UserFixture;
 import com.sopt.cherrish.domain.user.presentation.dto.request.UserUpdateRequestDto;
 import com.sopt.cherrish.domain.user.presentation.dto.response.UserResponseDto;
+import com.sopt.cherrish.domain.user.presentation.dto.response.UserSummaryResponseDto;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("UserService 단위 테스트")
@@ -33,22 +37,29 @@ class UserServiceTest {
 	@Mock
 	private UserRepository userRepository;
 
+	@Mock
+	private Clock clock;
+
 	@Test
 	@DisplayName("사용자 조회 성공")
 	void getUserSuccess() {
 		// given
 		Long userId = 1L;
 		User user = UserFixture.createUser("홍길동", 25);
+		ZoneId zoneId = ZoneId.of("Asia/Seoul");
+		Instant fixedInstant = user.getCreatedAt().atZone(zoneId).toInstant();
 
 		given(userRepository.findById(userId)).willReturn(Optional.of(user));
+		given(clock.getZone()).willReturn(zoneId);
+		given(clock.instant()).willReturn(fixedInstant);
 
 		// when
-		UserResponseDto result = userService.getUser(userId);
+		UserSummaryResponseDto result = userService.getUser(userId);
 
 		// then
 		assertThat(result).isNotNull();
 		assertThat(result.getName()).isEqualTo("홍길동");
-		assertThat(result.getAge()).isEqualTo(25);
+		assertThat(result.getDaysSinceSignup()).isEqualTo(1);
 	}
 
 	@Test

--- a/src/test/java/com/sopt/cherrish/domain/user/application/service/UserServiceTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/user/application/service/UserServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.verify;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Optional;
 
@@ -60,6 +61,29 @@ class UserServiceTest {
 		assertThat(result).isNotNull();
 		assertThat(result.getName()).isEqualTo("홍길동");
 		assertThat(result.getDaysSinceSignup()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("사용자 조회 성공 - 가입 N일차 계산")
+	void getUserSuccessWithElapsedDays() {
+		// given
+		Long userId = 1L;
+		LocalDateTime createdAt = LocalDateTime.of(2026, 1, 1, 10, 0, 0);
+		User user = UserFixture.createUser("홍길동", 25, createdAt);
+		ZoneId zoneId = ZoneId.of("Asia/Seoul");
+		Instant fixedInstant = createdAt.plusDays(2).atZone(zoneId).toInstant();
+
+		given(userRepository.findById(userId)).willReturn(Optional.of(user));
+		given(clock.getZone()).willReturn(zoneId);
+		given(clock.instant()).willReturn(fixedInstant);
+
+		// when
+		UserSummaryResponseDto result = userService.getUser(userId);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getName()).isEqualTo("홍길동");
+		assertThat(result.getDaysSinceSignup()).isEqualTo(3);
 	}
 
 	@Test

--- a/src/test/java/com/sopt/cherrish/domain/user/fixture/UserFixture.java
+++ b/src/test/java/com/sopt/cherrish/domain/user/fixture/UserFixture.java
@@ -30,6 +30,16 @@ public class UserFixture {
 		return user;
 	}
 
+	public static User createUser(String name, int age, LocalDateTime createdAt) {
+		User user = User.builder()
+			.name(name)
+			.age(age)
+			.build();
+		setField(user, User.class, "id", DEFAULT_ID);
+		setField(user, BaseTimeEntity.class, "createdAt", createdAt);
+		return user;
+	}
+
 	private static void setField(Object target, Class<?> clazz, String fieldName, Object value) {
 		try {
 			Field field = clazz.getDeclaredField(fieldName);

--- a/src/test/java/com/sopt/cherrish/domain/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/user/presentation/UserControllerTest.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sopt.cherrish.domain.user.application.service.UserService;
 import com.sopt.cherrish.domain.user.presentation.dto.request.UserUpdateRequestDto;
 import com.sopt.cherrish.domain.user.presentation.dto.response.UserResponseDto;
+import com.sopt.cherrish.domain.user.presentation.dto.response.UserSummaryResponseDto;
 
 @WebMvcTest(UserController.class)
 @DisplayName("UserController 통합 테스트")
@@ -43,12 +44,9 @@ class UserControllerTest {
 	void getUserSuccess() throws Exception {
 		// given
 		Long userId = 1L;
-		UserResponseDto response = UserResponseDto.builder()
-			.id(userId)
+		UserSummaryResponseDto response = UserSummaryResponseDto.builder()
 			.name("홍길동")
-			.age(25)
-			.createdAt(LocalDateTime.now())
-			.updatedAt(LocalDateTime.now())
+			.daysSinceSignup(3)
 			.build();
 
 		given(userService.getUser(userId)).willReturn(response);
@@ -58,7 +56,7 @@ class UserControllerTest {
 				.header("X-User-Id", userId))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.name").value("홍길동"))
-			.andExpect(jsonPath("$.data.age").value(25));
+			.andExpect(jsonPath("$.data.daysSinceSignup").value(3));
 	}
 
 	@Test


### PR DESCRIPTION
# 🛠 Related issue 🛠
- closed #66 

# ✏️ Work Description ✏️
- MY 탭 /api/users GET 응답을 이름 + 회원가입 경과일로 변경
  - 가입 당일 = 1일차 기준으로 경과일 계산
  - UserSummaryResponseDto 추가 및 서비스에서 계산 로직 처리
  - 관련 컨트롤러/서비스/테스트 수정

# 📸 Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 사용자 정보 조회 | <img width="193" height="136" alt="스크린샷 2026-01-13 오후 9 23 55" src="https://github.com/user-attachments/assets/4bc78769-68c1-486a-93ac-92e0a1c1ce40" /> |

# 😅 Uncompleted Tasks 😅
- 

# 📢 To Reviewers 📢
- 
