### PR TITLE
[Feature] 메인 대시보드 화면에 챌린지명 응답 추가

### DIFF
--- a/src/main/java/com/sopt/cherrish/domain/maindashboard/application/facade/MainDashboardFacade.java
+++ b/src/main/java/com/sopt/cherrish/domain/maindashboard/application/facade/MainDashboardFacade.java
@@ -54,6 +54,7 @@ public class MainDashboardFacade {
 		// 3. 챌린지 데이터 (활성 챌린지 없으면 0)
 		Integer cherryLevel = 0;
 		Double challengeRate = 0.0;
+		String challengeName = null;
 
 		var challengeOpt = challengeService.findActiveChallengeWithStatistics(userId);
 		if (challengeOpt.isPresent()) {
@@ -61,6 +62,7 @@ public class MainDashboardFacade {
 			ChallengeStatistics stats = challenge.getStatistics();
 			cherryLevel = stats.calculateCherryLevel();
 			challengeRate = stats.getProgressPercentage();
+			challengeName = challenge.getTitle();
 		} else {
 			log.info("사용자 {}의 활성 챌린지 없음 (cherryLevel=0)", userId);
 		}
@@ -96,7 +98,7 @@ public class MainDashboardFacade {
 
 		// 6. 응답 생성
 		return MainDashboardResponseDto.from(
-			today, cherryLevel, challengeRate,
+			today, cherryLevel, challengeRate, challengeName,
 			recentProcedures, upcomingProcedures
 		);
 	}

--- a/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/dto/response/MainDashboardResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/dto/response/MainDashboardResponseDto.java
@@ -14,9 +14,12 @@ import lombok.Getter;
 @Schema(description = "메인 대시보드 응답")
 public class MainDashboardResponseDto {
 
-	@Schema(description = "오늘 날짜", example = "2026-01-15")
-	@JsonFormat(pattern = "yyyy-MM-dd")
-	private LocalDate date;
+    @Schema(description = "오늘 날짜", example = "2026-01-15")
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate date;
+
+    @Schema(description = "진행 중인 챌린지 이름 (없으면 null)", example = "7일 보습 챌린지")
+    private String challengeName;
 
 	@Schema(description = "체리 레벨 (1-4, 챌린지 없으면 0)", example = "2")
 	private Integer cherryLevel;
@@ -34,12 +37,14 @@ public class MainDashboardResponseDto {
 		LocalDate today,
 		Integer cherryLevel,
 		Double challengeRate,
+		String challengeName,
 		List<RecentProcedureResponseDto> recentProcedures,
 		List<UpcomingProcedureResponseDto> upcomingProcedures
 	) {
 		return MainDashboardResponseDto.builder()
 			.date(today)
-			.cherryLevel(cherryLevel)
+            .challengeName(challengeName)
+            .cherryLevel(cherryLevel)
 			.challengeRate(challengeRate)
 			.recentProcedures(recentProcedures)
 			.upcomingProcedures(upcomingProcedures)

--- a/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/dto/response/MainDashboardResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/dto/response/MainDashboardResponseDto.java
@@ -14,12 +14,12 @@ import lombok.Getter;
 @Schema(description = "메인 대시보드 응답")
 public class MainDashboardResponseDto {
 
-    @Schema(description = "오늘 날짜", example = "2026-01-15")
-    @JsonFormat(pattern = "yyyy-MM-dd")
-    private LocalDate date;
+	@Schema(description = "오늘 날짜", example = "2026-01-15")
+	@JsonFormat(pattern = "yyyy-MM-dd")
+	private LocalDate date;
 
-    @Schema(description = "진행 중인 챌린지 이름 (없으면 null)", example = "7일 보습 챌린지")
-    private String challengeName;
+	@Schema(description = "진행 중인 챌린지 이름 (없으면 null)", example = "7일 보습 챌린지")
+	private String challengeName;
 
 	@Schema(description = "체리 레벨 (1-4, 챌린지 없으면 0)", example = "2")
 	private Integer cherryLevel;
@@ -43,8 +43,8 @@ public class MainDashboardResponseDto {
 	) {
 		return MainDashboardResponseDto.builder()
 			.date(today)
-            .challengeName(challengeName)
-            .cherryLevel(cherryLevel)
+			.challengeName(challengeName)
+			.cherryLevel(cherryLevel)
 			.challengeRate(challengeRate)
 			.recentProcedures(recentProcedures)
 			.upcomingProcedures(upcomingProcedures)

--- a/src/test/java/com/sopt/cherrish/domain/maindashboard/application/facade/MainDashboardFacadeTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/maindashboard/application/facade/MainDashboardFacadeTest.java
@@ -79,6 +79,7 @@ class MainDashboardFacadeTest {
 		// then
 		assertThat(result.getCherryLevel()).isEqualTo(0);
 		assertThat(result.getChallengeRate()).isEqualTo(0.0);
+		assertThat(result.getChallengeName()).isNull();
 		assertThat(result.getRecentProcedures()).isEmpty();
 		assertThat(result.getUpcomingProcedures()).isEmpty();
 	}
@@ -109,6 +110,7 @@ class MainDashboardFacadeTest {
 		// then
 		assertThat(result.getCherryLevel()).isEqualTo(0);
 		assertThat(result.getChallengeRate()).isEqualTo(0.0);
+		assertThat(result.getChallengeName()).isNull();
 		assertThat(result.getRecentProcedures()).isNotNull();
 	}
 
@@ -122,6 +124,7 @@ class MainDashboardFacadeTest {
 		given(challengeService.findActiveChallengeWithStatistics(userId))
 			.willReturn(Optional.of(challenge));
 		given(challenge.getStatistics()).willReturn(stats);
+		given(challenge.getTitle()).willReturn("7일 보습 챌린지");
 		given(stats.calculateCherryLevel()).willReturn(2);
 		given(stats.getProgressPercentage()).willReturn(40.0);
 
@@ -148,6 +151,7 @@ class MainDashboardFacadeTest {
 		MainDashboardResponseDto result = mainDashboardFacade.getMainDashboard(userId);
 
 		// then
+		assertThat(result.getChallengeName()).isEqualTo("7일 보습 챌린지");
 		assertThat(result.getRecentProcedures()).isEmpty();
 		assertThat(result.getUpcomingProcedures()).hasSize(1);
 	}
@@ -162,6 +166,7 @@ class MainDashboardFacadeTest {
 		given(challengeService.findActiveChallengeWithStatistics(userId))
 			.willReturn(Optional.of(challenge));
 		given(challenge.getStatistics()).willReturn(stats);
+		given(challenge.getTitle()).willReturn("7일 보습 챌린지");
 		given(stats.calculateCherryLevel()).willReturn(1);
 		given(stats.getProgressPercentage()).willReturn(10.0);
 
@@ -181,6 +186,7 @@ class MainDashboardFacadeTest {
 		MainDashboardResponseDto result = mainDashboardFacade.getMainDashboard(userId);
 
 		// then
+		assertThat(result.getChallengeName()).isEqualTo("7일 보습 챌린지");
 		assertThat(result.getUpcomingProcedures()).isEmpty();
 		assertThat(result.getRecentProcedures()).isNotNull();
 	}
@@ -195,6 +201,7 @@ class MainDashboardFacadeTest {
 		given(challengeService.findActiveChallengeWithStatistics(userId))
 			.willReturn(Optional.of(challenge));
 		given(challenge.getStatistics()).willReturn(stats);
+		given(challenge.getTitle()).willReturn("7일 보습 챌린지");
 		given(stats.calculateCherryLevel()).willReturn(3);
 		given(stats.getProgressPercentage()).willReturn(65.0);
 
@@ -232,6 +239,7 @@ class MainDashboardFacadeTest {
 		// then
 		assertThat(result.getCherryLevel()).isEqualTo(3);
 		assertThat(result.getChallengeRate()).isEqualTo(65.0);
+		assertThat(result.getChallengeName()).isEqualTo("7일 보습 챌린지");
 
 		List<RecentProcedureResponseDto> recent = result.getRecentProcedures();
 		assertThat(recent).hasSize(3);
@@ -259,6 +267,7 @@ class MainDashboardFacadeTest {
 		given(challengeService.findActiveChallengeWithStatistics(userId))
 			.willReturn(Optional.of(challenge));
 		given(challenge.getStatistics()).willReturn(stats);
+		given(challenge.getTitle()).willReturn("7일 보습 챌린지");
 		given(stats.calculateCherryLevel()).willReturn(4);
 		given(stats.getProgressPercentage()).willReturn(80.0);
 
@@ -316,6 +325,7 @@ class MainDashboardFacadeTest {
 		// then
 		assertThat(result.getCherryLevel()).isEqualTo(4);
 		assertThat(result.getChallengeRate()).isEqualTo(80.0);
+		assertThat(result.getChallengeName()).isEqualTo("7일 보습 챌린지");
 
 		List<RecentProcedureResponseDto> recent = result.getRecentProcedures();
 		assertThat(recent).hasSize(2);

--- a/src/test/java/com/sopt/cherrish/domain/maindashboard/presentation/MainDashboardControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/maindashboard/presentation/MainDashboardControllerTest.java
@@ -54,6 +54,7 @@ class MainDashboardControllerTest {
 			today,
 			3,
 			55.5,
+			"7일 보습 챌린지",
 			List.of(recent),
 			List.of(upcoming)
 		);
@@ -67,6 +68,7 @@ class MainDashboardControllerTest {
 			.andExpect(jsonPath("$.data.date").value("2026-01-15"))
 			.andExpect(jsonPath("$.data.cherryLevel").value(3))
 			.andExpect(jsonPath("$.data.challengeRate").value(55.5))
+			.andExpect(jsonPath("$.data.challengeName").value("7일 보습 챌린지"))
 			.andExpect(jsonPath("$.data.recentProcedures[0].name").value("레이저 토닝"))
 			.andExpect(jsonPath("$.data.upcomingProcedures[0].name").value("보톡스"));
 	}
@@ -95,6 +97,7 @@ class MainDashboardControllerTest {
 			today,
 			0,  // cherryLevel = 0
 			0.0,
+			null,
 			List.of(),
 			List.of()
 		);
@@ -128,6 +131,7 @@ class MainDashboardControllerTest {
 			today,
 			2,
 			45.0,
+			"7일 보습 챌린지",
 			List.of(),  // 빈 리스트
 			List.of(upcoming)
 		);
@@ -158,6 +162,7 @@ class MainDashboardControllerTest {
 			today,
 			3,
 			60.0,
+			"7일 보습 챌린지",
 			List.of(recent),
 			List.of()  // 빈 리스트
 		);


### PR DESCRIPTION
# 🛠 Related issue 🛠
- closed #72 

# ✏️ Work Description ✏️
- 메인 대시보드 응답에 진행 중인 챌린지명(`challengeName`) 필드 추가
- 컨트롤러/파사드 테스트에 챌린지명 응답 추가

# 📸 Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 메인 대시보드 조회 | <img width="304" height="397" alt="스크린샷 2026-01-14 오후 8 57 25" src="https://github.com/user-attachments/assets/e81159cb-963b-4867-afbf-a4dfffbeebdb" /> |

# 😅 Uncompleted Tasks 😅
- 

# 📢 To Reviewers 📢
- 

