### PR TITLE
[Task] 메인 대시보드 응답에 요일 추가

### DIFF
--- a/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/dto/response/MainDashboardResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/dto/response/MainDashboardResponseDto.java
@@ -18,6 +18,9 @@ public class MainDashboardResponseDto {
 	@JsonFormat(pattern = "yyyy-MM-dd")
 	private LocalDate date;
 
+	@Schema(description = "오늘 요일", example = "MONDAY")
+	private String dayOfWeek;
+
 	@Schema(description = "진행 중인 챌린지 이름 (없으면 null)", example = "7일 보습 챌린지")
 	private String challengeName;
 
@@ -43,6 +46,7 @@ public class MainDashboardResponseDto {
 	) {
 		return MainDashboardResponseDto.builder()
 			.date(today)
+			.dayOfWeek(today.getDayOfWeek().name())
 			.challengeName(challengeName)
 			.cherryLevel(cherryLevel)
 			.challengeRate(challengeRate)

--- a/src/test/java/com/sopt/cherrish/domain/maindashboard/application/facade/MainDashboardFacadeTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/maindashboard/application/facade/MainDashboardFacadeTest.java
@@ -80,6 +80,7 @@ class MainDashboardFacadeTest {
 		assertThat(result.getCherryLevel()).isEqualTo(0);
 		assertThat(result.getChallengeRate()).isEqualTo(0.0);
 		assertThat(result.getChallengeName()).isNull();
+		assertThat(result.getDayOfWeek()).isEqualTo(today.getDayOfWeek().name());
 		assertThat(result.getRecentProcedures()).isEmpty();
 		assertThat(result.getUpcomingProcedures()).isEmpty();
 	}

--- a/src/test/java/com/sopt/cherrish/domain/maindashboard/presentation/MainDashboardControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/maindashboard/presentation/MainDashboardControllerTest.java
@@ -39,6 +39,7 @@ class MainDashboardControllerTest {
 		// given
 		Long userId = 1L;
 		LocalDate today = LocalDate.of(2026, 1, 15);
+		String dayOfWeek = today.getDayOfWeek().name();
 		RecentProcedureResponseDto recent = RecentProcedureResponseDto.builder()
 			.name("레이저 토닝")
 			.daysSince(2)
@@ -66,6 +67,7 @@ class MainDashboardControllerTest {
 				.header("X-User-Id", userId))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.date").value("2026-01-15"))
+			.andExpect(jsonPath("$.data.dayOfWeek").value(dayOfWeek))
 			.andExpect(jsonPath("$.data.cherryLevel").value(3))
 			.andExpect(jsonPath("$.data.challengeRate").value(55.5))
 			.andExpect(jsonPath("$.data.challengeName").value("7일 보습 챌린지"))


### PR DESCRIPTION
# 🛠 Related issue 🛠
- closed #74 

# ✏️ Work Description ✏️
- 메인 대시보드 응답에 요일 필드 추가
  - `dayOfWeek` 값을 `LocalDate.getDayOfWeek().name()`로 설정
- 테스트 업데이트
   - 컨트롤러, 파사드 응답에 `dayOfWeek` 검증 추가

# 📸 Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 메인 대시보드 조회 |<img width="318" height="396" alt="스크린샷 2026-01-15 오전 12 03 58" src="https://github.com/user-attachments/assets/49117acf-f123-4398-acb6-1222687810d9" />|

# 😅 Uncompleted Tasks 😅
- 

# 📢 To Reviewers 📢
- `dayOfWeek`는 `MONDAY` 같은 enum name 형식입니다

