### PR TITLE
[Chore] ci/cd 트리거 브랜치 수정

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -3,7 +3,8 @@ name: CD Dev
 on:
   push:
     branches:
-      - develop
+      - release
+      - main
 
 permissions:
   id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
     branches:
+      - release
       - develop
       - main
 


### PR DESCRIPTION
# 🛠 Related issue 🛠
- closed #94

# ✏️ Work Description ✏️

develop branch에서 cd 수행시 워크플로우 시행 횟수가 너무 많아져 트리거 branch를 변경하였습니다.
이제 release branch에 병합 시 dev 서버 배포가 진행됩니다.
추후 main 병합시 운영 서버 배포 진행되게 변경할 예정입니다.

- CI 수행 브랜치에 release를 추가했습니다.
- CD 수행 브랜치에서 develop을 빼고 release를 추가했습니다.



# 😅 Uncompleted Tasks 😅
- 완료하지 못한 작업 내용


# 📢 To Reviewers 📢
- 리뷰 포인트

