### PR TITLE
[Enhancement] 유저 이름 글자수 및 나이 제한 변경

### DIFF
--- a/src/main/java/com/sopt/cherrish/domain/user/domain/model/User.java
+++ b/src/main/java/com/sopt/cherrish/domain/user/domain/model/User.java
@@ -23,7 +23,7 @@ public class User extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(nullable = false, length = 10)
+	@Column(nullable = false, length = 7)
 	private String name;
 
 	@Column(nullable = false)

--- a/src/main/java/com/sopt/cherrish/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/sopt/cherrish/domain/user/exception/UserErrorCode.java
@@ -10,7 +10,7 @@ public enum UserErrorCode implements ErrorType {
 	// User 도메인 에러 (U001 ~ U099)
 	USER_NOT_FOUND("U001", "사용자를 찾을 수 없습니다", 404),
 	INVALID_USER_NAME("U002", "유효하지 않은 사용자 이름입니다", 400),
-	INVALID_USER_AGE("U003", "유효하지 않은 나이입니다 (1-150세)", 400),
+	INVALID_USER_AGE("U003", "유효하지 않은 나이입니다 (1-100세)", 400),
 	USER_ALREADY_EXISTS("U004", "이미 존재하는 사용자입니다", 409);
 
 	private final String code;

--- a/src/main/java/com/sopt/cherrish/domain/user/presentation/dto/request/OnboardingRequestDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/user/presentation/dto/request/OnboardingRequestDto.java
@@ -13,13 +13,13 @@ import jakarta.validation.constraints.Size;
 public record OnboardingRequestDto(
 	@Schema(description = "사용자 이름", example = "홍길동", requiredMode = Schema.RequiredMode.REQUIRED)
 	@NotBlank(message = "이름은 필수입니다")
-	@Size(max = 10, message = "이름은 10자를 초과할 수 없습니다")
+	@Size(max = 7, message = "이름은 7자를 초과할 수 없습니다")
 	String name,
 
 	@Schema(description = "나이 (한국 나이)", example = "25", requiredMode = Schema.RequiredMode.REQUIRED)
 	@NotNull(message = "나이는 필수입니다")
 	@Min(value = 1, message = "나이는 1세 이상이어야 합니다")
-	@Max(value = 150, message = "나이는 150세 이하여야 합니다")
+	@Max(value = 100, message = "나이는 100세 이하여야 합니다")
 	Integer age
 ) {
 	// DTO -> Entity 변환

--- a/src/main/java/com/sopt/cherrish/domain/user/presentation/dto/request/UserUpdateRequestDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/user/presentation/dto/request/UserUpdateRequestDto.java
@@ -8,12 +8,12 @@ import jakarta.validation.constraints.Size;
 @Schema(description = "사용자 정보 수정 요청")
 public record UserUpdateRequestDto(
 	@Schema(description = "수정할 이름 (선택)", example = "김철수")
-	@Size(max = 10, message = "이름은 10자를 초과할 수 없습니다")
+	@Size(max = 7, message = "이름은 7자를 초과할 수 없습니다")
 	String name,
 
 	@Schema(description = "수정할 나이 (선택)", example = "30")
 	@Min(value = 1, message = "나이는 1세 이상이어야 합니다")
-	@Max(value = 150, message = "나이는 150세 이하여야 합니다")
+	@Max(value = 100, message = "나이는 100세 이하여야 합니다")
 	Integer age
 ) {
 }

--- a/src/test/java/com/sopt/cherrish/domain/user/presentation/OnboardingControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/user/presentation/OnboardingControllerTest.java
@@ -69,10 +69,10 @@ class OnboardingControllerTest {
 	}
 
 	@Test
-	@DisplayName("온보딩 프로필 생성 실패 - 이름이 10자 초과")
+	@DisplayName("온보딩 프로필 생성 실패 - 이름이 7자 초과")
 	void createProfileNameTooLong() throws Exception {
 		// given
-		OnboardingRequestDto request = new OnboardingRequestDto("가나다라마바사아자차카", 25);
+		OnboardingRequestDto request = new OnboardingRequestDto("가나다라마바사아", 25);
 
 		// when & then
 		mockMvc.perform(post("/api/onboarding/profiles")

--- a/src/test/java/com/sopt/cherrish/domain/user/presentation/OnboardingControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/user/presentation/OnboardingControllerTest.java
@@ -80,4 +80,30 @@ class OnboardingControllerTest {
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isBadRequest());
 	}
+
+	@Test
+	@DisplayName("온보딩 프로필 생성 실패 - 나이가 1세 미만")
+	void createProfileAgeTooLow() throws Exception {
+		// given
+		OnboardingRequestDto request = new OnboardingRequestDto("홍길동", 0);
+
+		// when & then
+		mockMvc.perform(post("/api/onboarding/profiles")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	@DisplayName("온보딩 프로필 생성 실패 - 나이가 100세 초과")
+	void createProfileAgeTooHigh() throws Exception {
+		// given
+		OnboardingRequestDto request = new OnboardingRequestDto("홍길동", 101);
+
+		// when & then
+		mockMvc.perform(post("/api/onboarding/profiles")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest());
+	}
 }

--- a/src/test/java/com/sopt/cherrish/domain/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/user/presentation/UserControllerTest.java
@@ -92,11 +92,11 @@ class UserControllerTest {
 	}
 
 	@Test
-	@DisplayName("사용자 정보 수정 실패 - 이름이 10자 초과")
+	@DisplayName("사용자 정보 수정 실패 - 이름이 7자 초과")
 	void updateUserNameTooLong() throws Exception {
 		// given
 		Long userId = 1L;
-		UserUpdateRequestDto request = new UserUpdateRequestDto("가나다라마바사아자차카", 30);
+		UserUpdateRequestDto request = new UserUpdateRequestDto("가나다라마바사아", 30);
 
 		// when & then
 		mockMvc.perform(patch("/api/users")


### PR DESCRIPTION
# 🛠 Related issue 🛠
- closed #95 

# ✏️ Work Description ✏️
- 유저 이름/나이 검증 범위 변경
  - 이름 최대 7자, 나이 1-100세로 제한
- 에러 메시지 범위 문구 수정
  - INVALID_USER_AGE 메시지 1-100세로 반영
- 관련 테스트 수정 및 확인
  - 이름 길이 검증 테스트 7자 기준으로 변경
  - 온보딩 시 나이 검증 테스트 추가


# 📸 Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
|  해당 없음  | N/A |


# 😅 Uncompleted Tasks 😅
- 


# 📢 To Reviewers 📢
- 

