### PR TITLE
[Enhancement] 챌린지 진행률 소수점 제거

### DIFF
--- a/src/main/java/com/sopt/cherrish/domain/challenge/core/domain/model/ChallengeStatistics.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/core/domain/model/ChallengeStatistics.java
@@ -83,12 +83,11 @@ public class ChallengeStatistics extends BaseTimeEntity {
 		}
 	}
 
-	public double getProgressPercentage() {
+	public int getProgressPercentage() {
 		if (totalRoutineCount == 0) {
-			return 0.0;
+			return 0;
 		}
-		double percentage = (double) completedCount / totalRoutineCount * 100;
-		return Math.round(percentage * 10.0) / 10.0;  // 소수점 1자리까지 반올림
+		return (int) Math.round((double) completedCount / totalRoutineCount * 100);
 	}
 
 	/**

--- a/src/main/java/com/sopt/cherrish/domain/challenge/core/presentation/dto/response/ChallengeDetailResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/core/presentation/dto/response/ChallengeDetailResponseDto.java
@@ -23,8 +23,8 @@ public record ChallengeDetailResponseDto(
 	@Schema(description = "현재 일차", example = "3")
 	int currentDay,
 
-	@Schema(description = "전체 진행률 (%)", example = "37.5")
-	double progressPercentage,
+	@Schema(description = "전체 진행률 (%)", example = "38")
+	int progressPercentage,
 
 	@Schema(description = "체리 레벨 (1-4)", example = "2")
 	int cherryLevel,

--- a/src/main/java/com/sopt/cherrish/domain/challenge/demo/domain/model/DemoChallengeStatistics.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/demo/domain/model/DemoChallengeStatistics.java
@@ -77,12 +77,11 @@ public class DemoChallengeStatistics extends BaseTimeEntity {
 		this.cherryLevel = calculateCherryLevel();
 	}
 
-	public double getProgressPercentage() {
+	public int getProgressPercentage() {
 		if (totalRoutineCount == 0) {
-			return 0.0;
+			return 0;
 		}
-		double percentage = (double) completedCount / totalRoutineCount * 100;
-		return Math.round(percentage * 10.0) / 10.0;
+		return (int) Math.round((double) completedCount / totalRoutineCount * 100);
 	}
 
 	/**

--- a/src/main/java/com/sopt/cherrish/domain/maindashboard/application/facade/MainDashboardFacade.java
+++ b/src/main/java/com/sopt/cherrish/domain/maindashboard/application/facade/MainDashboardFacade.java
@@ -53,7 +53,7 @@ public class MainDashboardFacade {
 
 		// 3. 챌린지 데이터 (활성 챌린지 없으면 0)
 		Integer cherryLevel = 0;
-		Double challengeRate = 0.0;
+		Integer challengeRate = 0;
 		String challengeName = null;
 
 		var challengeOpt = challengeService.findActiveChallengeWithStatistics(userId);

--- a/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/dto/response/MainDashboardResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/maindashboard/presentation/dto/response/MainDashboardResponseDto.java
@@ -22,8 +22,8 @@ public record MainDashboardResponseDto(
 	@Schema(description = "체리 레벨 (1-4, 챌린지 없으면 0)", example = "2")
 	Integer cherryLevel,
 
-	@Schema(description = "챌린지 완료율 (%)", example = "40.3")
-	Double challengeRate,
+	@Schema(description = "챌린지 완료율 (%)", example = "40")
+	Integer challengeRate,
 
 	@Schema(description = "최근 시술 목록 (다운타임 진행 중)")
 	List<RecentProcedureResponseDto> recentProcedures,
@@ -34,7 +34,7 @@ public record MainDashboardResponseDto(
 	public static MainDashboardResponseDto from(
 		LocalDate today,
 		Integer cherryLevel,
-		Double challengeRate,
+		Integer challengeRate,
 		String challengeName,
 		List<RecentProcedureResponseDto> recentProcedures,
 		List<UpcomingProcedureResponseDto> upcomingProcedures

--- a/src/test/java/com/sopt/cherrish/domain/challenge/core/application/facade/ChallengeQueryFacadeIntegrationTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/challenge/core/application/facade/ChallengeQueryFacadeIntegrationTest.java
@@ -110,7 +110,7 @@ class ChallengeQueryFacadeIntegrationTest {
 		assertThat(response.challengeId()).isEqualTo(challenge.getId());
 		assertThat(response.title()).isEqualTo(ChallengeTestFixture.DEFAULT_CHALLENGE_TITLE);
 		assertThat(response.currentDay()).isEqualTo(1);
-		assertThat(response.progressPercentage()).isEqualTo(0.0);
+		assertThat(response.progressPercentage()).isEqualTo(0);
 		assertThat(response.cherryLevel()).isEqualTo(1);
 		assertThat(response.progressToNextLevel()).isEqualTo(0.0);
 		assertThat(response.todayRoutines()).hasSize(3);
@@ -243,17 +243,16 @@ class ChallengeQueryFacadeIntegrationTest {
 
 	@ParameterizedTest
 	@CsvSource({
-		"5, 1, 23.0, 24.0",   // 21개 중 5개 완료 (23.8%) - 레벨 1
-		"8, 2, 38.0, 39.0",   // 21개 중 8개 완료 (38.1%) - 레벨 2
-		"13, 3, 61.0, 62.0",  // 21개 중 13개 완료 (61.9%) - 레벨 3
-		"16, 4, 76.0, 77.0"   // 21개 중 16개 완료 (76.2%) - 레벨 4
+		"5, 1, 24",   // 21개 중 5개 완료 (23.8% -> 24%) - 레벨 1
+		"8, 2, 38",   // 21개 중 8개 완료 (38.1% -> 38%) - 레벨 2
+		"13, 3, 62",  // 21개 중 13개 완료 (61.9% -> 62%) - 레벨 3
+		"16, 4, 76"   // 21개 중 16개 완료 (76.2% -> 76%) - 레벨 4
 	})
 	@DisplayName("성공 - 체리 레벨별 진행도 계산 정확성")
 	void getActiveChallengeDetailCherryLevels(
 		int completeCount,
 		int expectedLevel,
-		double minProgress,
-		double maxProgress
+		int expectedProgress
 	) {
 		// given
 		LocalDate startDate = ChallengeTestFixture.FIXED_START_DATE;
@@ -267,7 +266,7 @@ class ChallengeQueryFacadeIntegrationTest {
 
 		// then
 		assertThat(response.cherryLevel()).isEqualTo(expectedLevel);
-		assertThat(response.progressPercentage()).isBetween(minProgress, maxProgress);
+		assertThat(response.progressPercentage()).isEqualTo(expectedProgress);
 
 		// 레벨 4가 아닌 경우 다음 레벨까지 진행도 검증
 		if (expectedLevel < 4) {

--- a/src/test/java/com/sopt/cherrish/domain/challenge/core/application/service/challengeroutine/ChallengeRoutineBatchUpdateIntegrationTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/challenge/core/application/service/challengeroutine/ChallengeRoutineBatchUpdateIntegrationTest.java
@@ -302,8 +302,7 @@ class ChallengeRoutineBatchUpdateIntegrationTest {
 			assertSoftly(softly -> {
 				softly.assertThat(stats.getCompletedCount()).isEqualTo(6);
 				softly.assertThat(stats.getCherryLevel()).isEqualTo(2);
-				softly.assertThat(stats.getProgressPercentage())
-					.isCloseTo(28.5, org.assertj.core.data.Offset.offset(0.1));
+				softly.assertThat(stats.getProgressPercentage()).isEqualTo(29);  // 28.5% → 29
 			});
 		}
 
@@ -342,8 +341,7 @@ class ChallengeRoutineBatchUpdateIntegrationTest {
 			assertSoftly(softly -> {
 				softly.assertThat(stats.getCompletedCount()).isEqualTo(10);
 				softly.assertThat(stats.getCherryLevel()).isEqualTo(2);
-				softly.assertThat(stats.getProgressPercentage())
-					.isCloseTo(47.6, org.assertj.core.data.Offset.offset(0.1));
+				softly.assertThat(stats.getProgressPercentage()).isEqualTo(48);  // 47.6% → 48
 			});
 		}
 	}

--- a/src/test/java/com/sopt/cherrish/domain/challenge/core/application/service/challengeroutine/ChallengeRoutineToggleIntegrationTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/challenge/core/application/service/challengeroutine/ChallengeRoutineToggleIntegrationTest.java
@@ -185,32 +185,32 @@ class ChallengeRoutineToggleIntegrationTest {
 			List<ChallengeRoutine> allRoutines = routineRepository.findByChallengeId(challenge.getId());
 
 			// Level 1: 0% ~ 24.99%
-			// 5개 완료 = 23.8% → 레벨 1
+			// 5개 완료 = 23.8% → 24% (반올림) → 레벨 1
 			completeRoutines(user, allRoutines, 0, 5);
-			assertCherryLevelWithProgress(challenge, 1, 5, 23.8);
+			assertCherryLevelWithProgress(challenge, 1, 5, 24);
 
 			// Level 2: 25% ~ 49.99%
-			// 6개 완료 = 28.5% → 레벨 2
+			// 6개 완료 = 28.5% → 29% (반올림) → 레벨 2
 			completeRoutines(user, allRoutines, 5, 6);
-			assertCherryLevelWithProgress(challenge, 2, 6, 28.5);
+			assertCherryLevelWithProgress(challenge, 2, 6, 29);
 
-			// 10개 완료 = 47.6% → 레벨 2
+			// 10개 완료 = 47.6% → 48% (반올림) → 레벨 2
 			completeRoutines(user, allRoutines, 6, 10);
-			assertCherryLevelWithProgress(challenge, 2, 10, 47.6);
+			assertCherryLevelWithProgress(challenge, 2, 10, 48);
 
 			// Level 3: 50% ~ 74.99%
-			// 11개 완료 = 52.3% → 레벨 3
+			// 11개 완료 = 52.3% → 52% (반올림) → 레벨 3
 			completeRoutines(user, allRoutines, 10, 11);
-			assertCherryLevelWithProgress(challenge, 3, 11, 52.3);
+			assertCherryLevelWithProgress(challenge, 3, 11, 52);
 
 			// Level 4: 75% ~ 100%
-			// 16개 완료 = 76.1% → 레벨 4
+			// 16개 완료 = 76.1% → 76% (반올림) → 레벨 4
 			completeRoutines(user, allRoutines, 11, 16);
-			assertCherryLevelWithProgress(challenge, 4, 16, 76.1);
+			assertCherryLevelWithProgress(challenge, 4, 16, 76);
 
 			// 21개 완료 = 100% → 레벨 4
 			completeRoutines(user, allRoutines, 16, 21);
-			assertCherryLevelWithProgress(challenge, 4, 21, 100.0);
+			assertCherryLevelWithProgress(challenge, 4, 21, 100);
 		}
 	}
 
@@ -402,13 +402,12 @@ class ChallengeRoutineToggleIntegrationTest {
 	}
 
 	private void assertCherryLevelWithProgress(Challenge challenge, int expectedLevel, int expectedCount,
-		double expectedProgress) {
+		int expectedProgress) {
 		ChallengeStatistics stats = statisticsRepository.findByChallengeId(challenge.getId()).orElseThrow();
 		assertSoftly(softly -> {
 			softly.assertThat(stats.getCherryLevel()).isEqualTo(expectedLevel);
 			softly.assertThat(stats.getCompletedCount()).isEqualTo(expectedCount);
-			softly.assertThat(stats.getProgressPercentage())
-				.isCloseTo(expectedProgress, org.assertj.core.data.Offset.offset(0.1));
+			softly.assertThat(stats.getProgressPercentage()).isEqualTo(expectedProgress);
 		});
 	}
 }

--- a/src/test/java/com/sopt/cherrish/domain/challenge/core/fixture/ChallengeTestFixture.java
+++ b/src/test/java/com/sopt/cherrish/domain/challenge/core/fixture/ChallengeTestFixture.java
@@ -125,7 +125,7 @@ public class ChallengeTestFixture {
 			DEFAULT_CHALLENGE_ID,
 			"7일 보습 챌린지",
 			3,
-			42.5,
+			43,
 			2,
 			"꽃핀 체리",
 			50.0,

--- a/src/test/java/com/sopt/cherrish/domain/maindashboard/application/facade/MainDashboardFacadeTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/maindashboard/application/facade/MainDashboardFacadeTest.java
@@ -78,7 +78,7 @@ class MainDashboardFacadeTest {
 
 		// then
 		assertThat(result.cherryLevel()).isEqualTo(0);
-		assertThat(result.challengeRate()).isEqualTo(0.0);
+		assertThat(result.challengeRate()).isEqualTo(0);
 		assertThat(result.challengeName()).isNull();
 		assertThat(result.dayOfWeek()).isEqualTo(today.getDayOfWeek().name());
 		assertThat(result.recentProcedures()).isEmpty();
@@ -110,7 +110,7 @@ class MainDashboardFacadeTest {
 
 		// then
 		assertThat(result.cherryLevel()).isEqualTo(0);
-		assertThat(result.challengeRate()).isEqualTo(0.0);
+		assertThat(result.challengeRate()).isEqualTo(0);
 		assertThat(result.challengeName()).isNull();
 		assertThat(result.recentProcedures()).isNotNull();
 	}
@@ -127,7 +127,7 @@ class MainDashboardFacadeTest {
 		given(challenge.getStatistics()).willReturn(stats);
 		given(challenge.getTitle()).willReturn("7일 보습 챌린지");
 		given(stats.calculateCherryLevel()).willReturn(2);
-		given(stats.getProgressPercentage()).willReturn(40.0);
+		given(stats.getProgressPercentage()).willReturn(40);
 
 		given(userProcedureService.findRecentProcedures(userId, today))
 			.willReturn(List.of());
@@ -169,7 +169,7 @@ class MainDashboardFacadeTest {
 		given(challenge.getStatistics()).willReturn(stats);
 		given(challenge.getTitle()).willReturn("7일 보습 챌린지");
 		given(stats.calculateCherryLevel()).willReturn(1);
-		given(stats.getProgressPercentage()).willReturn(10.0);
+		given(stats.getProgressPercentage()).willReturn(10);
 
 		var user = UserFixture.createUser();
 		UserProcedure recent = UserProcedureFixture.createUserProcedure(
@@ -204,7 +204,7 @@ class MainDashboardFacadeTest {
 		given(challenge.getStatistics()).willReturn(stats);
 		given(challenge.getTitle()).willReturn("7일 보습 챌린지");
 		given(stats.calculateCherryLevel()).willReturn(3);
-		given(stats.getProgressPercentage()).willReturn(65.0);
+		given(stats.getProgressPercentage()).willReturn(65);
 
 		var user = UserFixture.createUser();
 		// 1/10 시술 (다운타임 7일) - 1/15 기준 RECOVERY
@@ -239,7 +239,7 @@ class MainDashboardFacadeTest {
 
 		// then
 		assertThat(result.cherryLevel()).isEqualTo(3);
-		assertThat(result.challengeRate()).isEqualTo(65.0);
+		assertThat(result.challengeRate()).isEqualTo(65);
 		assertThat(result.challengeName()).isEqualTo("7일 보습 챌린지");
 
 		List<RecentProcedureResponseDto> recent = result.recentProcedures();
@@ -270,7 +270,7 @@ class MainDashboardFacadeTest {
 		given(challenge.getStatistics()).willReturn(stats);
 		given(challenge.getTitle()).willReturn("7일 보습 챌린지");
 		given(stats.calculateCherryLevel()).willReturn(4);
-		given(stats.getProgressPercentage()).willReturn(80.0);
+		given(stats.getProgressPercentage()).willReturn(80);
 
 		var user = UserFixture.createUser();
 		UserProcedure recent1 = UserProcedureFixture.createUserProcedure(
@@ -325,7 +325,7 @@ class MainDashboardFacadeTest {
 
 		// then
 		assertThat(result.cherryLevel()).isEqualTo(4);
-		assertThat(result.challengeRate()).isEqualTo(80.0);
+		assertThat(result.challengeRate()).isEqualTo(80);
 		assertThat(result.challengeName()).isEqualTo("7일 보습 챌린지");
 
 		List<RecentProcedureResponseDto> recent = result.recentProcedures();

--- a/src/test/java/com/sopt/cherrish/domain/maindashboard/presentation/MainDashboardControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/maindashboard/presentation/MainDashboardControllerTest.java
@@ -54,7 +54,7 @@ class MainDashboardControllerTest {
 		MainDashboardResponseDto response = MainDashboardResponseDto.from(
 			today,
 			3,
-			55.5,
+			56,
 			"7일 보습 챌린지",
 			List.of(recent),
 			List.of(upcoming)
@@ -69,7 +69,7 @@ class MainDashboardControllerTest {
 			.andExpect(jsonPath("$.data.date").value("2026-01-15"))
 			.andExpect(jsonPath("$.data.dayOfWeek").value(dayOfWeek))
 			.andExpect(jsonPath("$.data.cherryLevel").value(3))
-			.andExpect(jsonPath("$.data.challengeRate").value(55.5))
+			.andExpect(jsonPath("$.data.challengeRate").value(56))
 			.andExpect(jsonPath("$.data.challengeName").value("7일 보습 챌린지"))
 			.andExpect(jsonPath("$.data.recentProcedures[0].name").value("레이저 토닝"))
 			.andExpect(jsonPath("$.data.upcomingProcedures[0].name").value("보톡스"));
@@ -98,7 +98,7 @@ class MainDashboardControllerTest {
 		MainDashboardResponseDto response = MainDashboardResponseDto.from(
 			today,
 			0,  // cherryLevel = 0
-			0.0,
+			0,
 			null,
 			List.of(),
 			List.of()
@@ -110,7 +110,7 @@ class MainDashboardControllerTest {
 				.header("X-User-Id", userId))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.cherryLevel").value(0))
-			.andExpect(jsonPath("$.data.challengeRate").value(0.0))
+			.andExpect(jsonPath("$.data.challengeRate").value(0))
 			.andExpect(jsonPath("$.data.recentProcedures").isArray())
 			.andExpect(jsonPath("$.data.recentProcedures").isEmpty())
 			.andExpect(jsonPath("$.data.upcomingProcedures").isArray())
@@ -132,7 +132,7 @@ class MainDashboardControllerTest {
 		MainDashboardResponseDto response = MainDashboardResponseDto.from(
 			today,
 			2,
-			45.0,
+			45,
 			"7일 보습 챌린지",
 			List.of(),  // 빈 리스트
 			List.of(upcoming)
@@ -163,7 +163,7 @@ class MainDashboardControllerTest {
 		MainDashboardResponseDto response = MainDashboardResponseDto.from(
 			today,
 			3,
-			60.0,
+			60,
 			"7일 보습 챌린지",
 			List.of(recent),
 			List.of()  // 빈 리스트


### PR DESCRIPTION
  # 🛠 Related issue 🛠

  - closed #100

  # ✏️ Work Description ✏️

  - progressPercentage 타입 변경 (double → int)
    - ChallengeStatistics.getProgressPercentage() 반환 타입 변경
    - DemoChallengeStatistics.getProgressPercentage() 반환 타입 변경
    - ChallengeDetailResponseDto.progressPercentage 필드 타입 변경
    - MainDashboardResponseDto.challengeRate 필드 타입 변경 (Double → Integer)
    - MainDashboardFacade 내부 변수 타입 변경
  - 반올림 로직 변경
    - 기존: 소수점 첫째 자리까지 반올림 (예: 23.8%)
    - 변경: 정수로 반올림 (예: 24%)
  - 테스트 코드 수정
    - ChallengeQueryFacadeIntegrationTest                                                                                                                                                                
    - ChallengeRoutineBatchUpdateIntegrationTest                                                                                                                                                         
    - ChallengeRoutineToggleIntegrationTest                                                                                                                                                              
    - ChallengeTestFixture                                                                                                                                                                               
    - MainDashboardFacadeTest                                                                                                                                                                            
    - MainDashboardControllerTest                                                                                                                                                                        


# 📸 Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
|        챌린지 조회 API      | <img width="1690" height="1000" alt="image" src="https://github.com/user-attachments/assets/fbb2eb4a-b7a9-4133-9404-3aa9926144ce" /> |

# 😅 Uncompleted Tasks 😅

  - 없음

  # 📢 To Reviewers 📢

  - getProgressPercentage() 내부에서 사용하는 calculateCherryLevel(), getProgressToNextLevel() 메서드는 내부 계산 정확도를 위해 double로 유지했습니다
  - 기존 API 응답에서 37.5 형태로 나오던 값이 38로 변경됩니다