### PR TITLE
[Chore] application.yml 설정 명시적으로 지정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
 	// Logging
 	implementation 'net.logstash.logback:logstash-logback-encoder:8.1'
 	implementation 'com.github.napstr:logback-discord-appender:1.0.0'
-
+1
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
 	// Logging
 	implementation 'net.logstash.logback:logstash-logback-encoder:8.1'
 	implementation 'com.github.napstr:logback-discord-appender:1.0.0'
-1
+
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -23,3 +23,9 @@ logging:
     root: INFO
     com.sopt.cherrish: DEBUG
     org.hibernate.SQL: DEBUG
+
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    enabled: true

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -5,6 +5,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+    open-in-view: false
   swagger:
     base-url: http://localhost:8080
 
@@ -14,3 +15,9 @@ logging:
     com.sopt.cherrish: DEBUG
     org.hibernate.SQL: DEBUG
     org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    enabled: true

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -23,3 +23,9 @@ logging:
     root: INFO
     com.sopt.cherrish: INFO
     org.hibernate.SQL: WARN
+
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false


### PR DESCRIPTION
# 🛠 Related issue 🛠
  - closed #110

  # ✏️ Work Description ✏️
  - application-local.yaml
      - `spring.jpa.open-in-view: false` 설정 추가
      - `springdoc.api-docs.enabled: true` 설정 추가
      - `springdoc.swagger-ui.enabled: true` 설정 추가
  - application-dev.yaml
      - `springdoc.api-docs.enabled: true` 설정 추가
      - `springdoc.swagger-ui.enabled: true` 설정 추가
  - application-prod.yaml
      - `springdoc.api-docs.enabled: false` 설정 추가
      - `springdoc.swagger-ui.enabled: false` 설정 추가

  # 📸 Screenshot 📸


  # 😅 Uncompleted Tasks 😅
  - 로컬/개발 환경에서 SpringDoc 경고는 정보성 메시지로 유지 (운영 환경에서만 비활성화)

  # 📢 To Reviewers 📢

  ## open-in-view: false 설정 이유

  OSIV(Open Session In View)는 HTTP 요청 시작부터 응답 완료까지 영속성 컨텍스트를 유지하는 패턴입니다.

  ### `open-in-view: true` (기본값)의 문제점

  **1. DB 커넥션 오래 점유**
```
  요청 시작 → Controller → Service → Repository → View 렌더링 → 응답 완료
             |<------------ DB 커넥션 점유 중 ------------->|
```
View 렌더링까지 커넥션을 잡고 있어서 커넥션 풀이 빨리 고갈됩니다.

  **2. 예상치 못한 쿼리 발생**
  ```java
  // Controller에서
  User user = userService.findById(1L);
  return user.getPosts();  // Lazy Loading → 여기서 SELECT 쿼리 발생!
  Service 밖에서 쿼리가 나가면 트랜잭션 범위를 벗어나 N+1 문제 추적이 어렵습니다.
```

  3. 레이어 책임 분리 위반

  Controller/View가 DB 접근 가능 → 비즈니스 로직이 Controller로 새어나갈 수 있습니다.

  open-in-view: false 설정 시

  - DB 커넥션을 트랜잭션 종료 시 즉시 반환
  - Lazy Loading은 Service 레이어에서만 가능
  - 필요한 데이터는 Service에서 미리 fetch 필요

```
  ┌─────────────────────────────┬────────────────┬────────────────────────────────────┐
  │            항목             │ true (기본값)  │            false (권장)            │
  ├─────────────────────────────┼────────────────┼────────────────────────────────────┤
  │ DB 커넥션 점유              │ 응답 완료까지  │ 트랜잭션 종료 시 반환              │
  ├─────────────────────────────┼────────────────┼────────────────────────────────────┤
  │ Controller에서 Lazy Loading │ 가능           │ 불가 (LazyInitializationException) │
  ├─────────────────────────────┼────────────────┼────────────────────────────────────┤
  │ 성능                        │ 커넥션 풀 부담 │ 효율적                             │
  └─────────────────────────────┴────────────────┴────────────────────────────────────┘
```

  SpringDoc 설정

  - 운영 환경에서는 Swagger UI가 비활성화되어 API 스펙이 노출되지 않습니다.
