### PR TITLE
[Enhancement] 캘린더 다운타임 상세 조회 시 회복 목표일 추가

### DIFF
--- a/src/main/java/com/sopt/cherrish/domain/calendar/presentation/dto/response/ProcedureEventDowntimeResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/calendar/presentation/dto/response/ProcedureEventDowntimeResponseDto.java
@@ -24,6 +24,10 @@ public record ProcedureEventDowntimeResponseDto(
 	@Schema(description = "다운타임(일)", example = "7")
 	Integer downtimeDays,
 
+	@Schema(description = "회복 목표일", example = "2026-01-22")
+	@JsonFormat(pattern = "yyyy-MM-dd")
+	LocalDate recoveryTargetDate,
+
 	@Schema(description = "민감기 날짜 목록", example = "[\"2026-01-15\", \"2026-01-16\", \"2026-01-17\"]")
 	@JsonSerialize(contentUsing = LocalDateSerializer.class)
 	List<LocalDate> sensitiveDays,
@@ -43,6 +47,7 @@ public record ProcedureEventDowntimeResponseDto(
 			userProcedure.getId(),
 			userProcedure.getScheduledAt(),
 			userProcedure.getDowntimeDays(),
+			userProcedure.getRecoveryTargetDate(),
 			downtimePeriod.getSensitiveDays(),
 			downtimePeriod.getCautionDays(),
 			downtimePeriod.getRecoveryDays()

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/model/UserProcedure.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/model/UserProcedure.java
@@ -52,12 +52,22 @@ public class UserProcedure extends BaseTimeEntity {
 	@Column(name = "downtime_days", nullable = false)
 	private Integer downtimeDays;
 
+	@Column(name = "recovery_target_date", nullable = true)
+	private LocalDate recoveryTargetDate;
+
 	@Builder
-	private UserProcedure(User user, Procedure procedure, LocalDateTime scheduledAt, Integer downtimeDays) {
+	private UserProcedure(
+		User user,
+		Procedure procedure,
+		LocalDateTime scheduledAt,
+		Integer downtimeDays,
+		LocalDate recoveryTargetDate
+	) {
 		this.user = user;
 		this.procedure = procedure;
 		this.scheduledAt = scheduledAt;
 		this.downtimeDays = downtimeDays;
+		this.recoveryTargetDate = recoveryTargetDate;
 	}
 
 	/**

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/model/UserProcedure.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/domain/model/UserProcedure.java
@@ -52,7 +52,7 @@ public class UserProcedure extends BaseTimeEntity {
 	@Column(name = "downtime_days", nullable = false)
 	private Integer downtimeDays;
 
-	@Column(name = "recovery_target_date", nullable = true)
+	@Column(name = "recovery_target_date")
 	private LocalDate recoveryTargetDate;
 
 	@Builder

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/request/UserProcedureCreateRequestDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/request/UserProcedureCreateRequestDto.java
@@ -1,5 +1,6 @@
 package com.sopt.cherrish.domain.userprocedure.presentation.dto.request;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -21,6 +22,9 @@ public record UserProcedureCreateRequestDto(
 	@NotNull(message = "예약 날짜 및 시간은 필수입니다")
 	LocalDateTime scheduledAt,
 
+	@Schema(description = "회복 목표일", example = "2026-01-22")
+	LocalDate recoveryTargetDate,
+
 	@Schema(description = "시술 목록", requiredMode = Schema.RequiredMode.REQUIRED)
 	@NotEmpty(message = "시술 목록은 비어 있을 수 없습니다")
 	@Valid
@@ -36,6 +40,7 @@ public record UserProcedureCreateRequestDto(
 				.procedure(procedureMap.get(item.procedureId()))
 				.scheduledAt(scheduledAt)
 				.downtimeDays(item.downtimeDays())
+				.recoveryTargetDate(recoveryTargetDate)
 				.build())
 			.toList();
 	}

--- a/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/response/UserProcedureResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/response/UserProcedureResponseDto.java
@@ -1,5 +1,6 @@
 package com.sopt.cherrish.domain.userprocedure.presentation.dto.response;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -23,7 +24,11 @@ public record UserProcedureResponseDto(
 	LocalDateTime scheduledAt,
 
 	@Schema(description = "개인 다운타임(일)", example = "6")
-	Integer downtimeDays
+	Integer downtimeDays,
+
+	@Schema(description = "회복 목표일", example = "2026-01-10")
+	@JsonFormat(pattern = "yyyy-MM-dd")
+	LocalDate recoveryTargetDate
 ) {
 	public static UserProcedureResponseDto from(UserProcedure userProcedure) {
 		return new UserProcedureResponseDto(
@@ -31,7 +36,8 @@ public record UserProcedureResponseDto(
 			userProcedure.getProcedure().getId(),
 			userProcedure.getProcedure().getName(),
 			userProcedure.getScheduledAt(),
-			userProcedure.getDowntimeDays()
+			userProcedure.getDowntimeDays(),
+			userProcedure.getRecoveryTargetDate()
 		);
 	}
 }

--- a/src/test/java/com/sopt/cherrish/domain/calendar/application/service/CalendarServiceTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/calendar/application/service/CalendarServiceTest.java
@@ -166,11 +166,12 @@ class CalendarServiceTest {
 		// given
 		Long userId = 1L;
 		Long userProcedureId = 101L;
+		LocalDate recoveryTargetDate = LocalDate.of(2025, 1, 20);
 
 		User mockUser = createMockUser("테스트 사용자", 25);
 		Procedure mockProcedure = createMockProcedure("레이저 토닝");
 		UserProcedure userProcedure = createUserProcedure(
-			mockUser, mockProcedure, LocalDateTime.of(2025, 1, 15, 14, 0), downtimeDays);
+			mockUser, mockProcedure, LocalDateTime.of(2025, 1, 15, 14, 0), downtimeDays, recoveryTargetDate);
 
 		given(userRepository.existsById(userId)).willReturn(true);
 		given(userProcedureRepository.findByIdAndUserId(userProcedureId, userId))
@@ -181,6 +182,7 @@ class CalendarServiceTest {
 
 		// then
 		assertThat(result.downtimeDays()).isEqualTo(downtimeDays);
+		assertThat(result.recoveryTargetDate()).isEqualTo(recoveryTargetDate);
 		assertThat(result.sensitiveDays()).hasSize(expectedSensitive);
 		assertThat(result.cautionDays()).hasSize(expectedCaution);
 		assertThat(result.recoveryDays()).hasSize(expectedRecovery);

--- a/src/test/java/com/sopt/cherrish/domain/calendar/fixture/CalendarTestFixture.java
+++ b/src/test/java/com/sopt/cherrish/domain/calendar/fixture/CalendarTestFixture.java
@@ -36,11 +36,22 @@ public class CalendarTestFixture {
 		LocalDateTime scheduledAt,
 		int downtimeDays
 	) {
+		return createUserProcedure(user, procedure, scheduledAt, downtimeDays, null);
+	}
+
+	public static UserProcedure createUserProcedure(
+		User user,
+		Procedure procedure,
+		LocalDateTime scheduledAt,
+		int downtimeDays,
+		LocalDate recoveryTargetDate
+	) {
 		return UserProcedure.builder()
 			.user(user)
 			.procedure(procedure)
 			.scheduledAt(scheduledAt)
 			.downtimeDays(downtimeDays)
+			.recoveryTargetDate(recoveryTargetDate)
 			.build();
 	}
 
@@ -67,6 +78,7 @@ public class CalendarTestFixture {
 		Long userProcedureId,
 		LocalDateTime scheduledAt,
 		int downtimeDays,
+		LocalDate recoveryTargetDate,
 		List<LocalDate> sensitiveDays,
 		List<LocalDate> cautionDays,
 		List<LocalDate> recoveryDays
@@ -75,6 +87,7 @@ public class CalendarTestFixture {
 			userProcedureId,
 			scheduledAt,
 			downtimeDays,
+			recoveryTargetDate,
 			sensitiveDays,
 			cautionDays,
 			recoveryDays

--- a/src/test/java/com/sopt/cherrish/domain/calendar/presentation/CalendarControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/calendar/presentation/CalendarControllerTest.java
@@ -158,6 +158,7 @@ class CalendarControllerTest {
 			userProcedureId,
 			LocalDateTime.of(2025, 1, 15, 14, 0),
 			9,
+			LocalDate.of(2025, 1, 24),
 			List.of(
 				LocalDate.of(2025, 1, 15),
 				LocalDate.of(2025, 1, 16),
@@ -183,6 +184,7 @@ class CalendarControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.userProcedureId").value(123))
 			.andExpect(jsonPath("$.data.downtimeDays").value(9))
+			.andExpect(jsonPath("$.data.recoveryTargetDate").value("2025-01-24"))
 			.andExpect(jsonPath("$.data.sensitiveDays").isArray())
 			.andExpect(jsonPath("$.data.sensitiveDays.length()").value(3))
 			.andExpect(jsonPath("$.data.cautionDays").isArray())

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/application/service/UserProcedureServiceTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/application/service/UserProcedureServiceTest.java
@@ -64,6 +64,7 @@ class UserProcedureServiceTest {
 
 		UserProcedureCreateRequestDto request = new UserProcedureCreateRequestDto(
 			scheduledAt,
+			null,
 			List.of(
 				new UserProcedureCreateRequestItemDto(procedure1.getId(), 6),
 				new UserProcedureCreateRequestItemDto(procedure2.getId(), 3)
@@ -99,6 +100,7 @@ class UserProcedureServiceTest {
 		Long userId = 999L;
 		UserProcedureCreateRequestDto request = new UserProcedureCreateRequestDto(
 			LocalDateTime.of(2025, 1, 1, 16, 0),
+			null,
 			List.of(new UserProcedureCreateRequestItemDto(1L, 6))
 		);
 
@@ -121,6 +123,7 @@ class UserProcedureServiceTest {
 
 		UserProcedureCreateRequestDto request = new UserProcedureCreateRequestDto(
 			scheduledAt,
+			null,
 			List.of(
 				new UserProcedureCreateRequestItemDto(procedure.getId(), 6),
 				new UserProcedureCreateRequestItemDto(999L, 3)
@@ -147,6 +150,7 @@ class UserProcedureServiceTest {
 
 		UserProcedureCreateRequestDto request = new UserProcedureCreateRequestDto(
 			scheduledAt,
+			null,
 			List.of(new UserProcedureCreateRequestItemDto(procedure.getId(), 0))
 		);
 
@@ -180,6 +184,7 @@ class UserProcedureServiceTest {
 
 		UserProcedureCreateRequestDto request = new UserProcedureCreateRequestDto(
 			scheduledAt,
+			null,
 			List.of(
 				new UserProcedureCreateRequestItemDto(procedure1.getId(), 5),
 				new UserProcedureCreateRequestItemDto(procedure2.getId(), 7),

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/fixture/UserProcedureFixture.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/fixture/UserProcedureFixture.java
@@ -1,6 +1,7 @@
 package com.sopt.cherrish.domain.userprocedure.fixture;
 
 import java.lang.reflect.Field;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -23,7 +24,7 @@ public class UserProcedureFixture {
 		LocalDateTime scheduledAt,
 		Integer downtimeDays
 	) {
-		return createUserProcedure(ID_GENERATOR.getAndIncrement(), user, procedure, scheduledAt, downtimeDays);
+		return createUserProcedure(ID_GENERATOR.getAndIncrement(), user, procedure, scheduledAt, downtimeDays, null);
 	}
 
 	public static UserProcedure createUserProcedure(
@@ -33,11 +34,23 @@ public class UserProcedureFixture {
 		LocalDateTime scheduledAt,
 		Integer downtimeDays
 	) {
+		return createUserProcedure(id, user, procedure, scheduledAt, downtimeDays, null);
+	}
+
+	public static UserProcedure createUserProcedure(
+		Long id,
+		User user,
+		Procedure procedure,
+		LocalDateTime scheduledAt,
+		Integer downtimeDays,
+		LocalDate recoveryTargetDate
+	) {
 		UserProcedure userProcedure = UserProcedure.builder()
 			.user(user)
 			.procedure(procedure)
 			.scheduledAt(scheduledAt)
 			.downtimeDays(downtimeDays)
+			.recoveryTargetDate(recoveryTargetDate)
 			.build();
 		setField(userProcedure, UserProcedure.class, "id", id);
 		setField(userProcedure, BaseTimeEntity.class, "createdAt", LocalDateTime.now());

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/fixture/UserProcedureTestFixture.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/fixture/UserProcedureTestFixture.java
@@ -1,5 +1,6 @@
 package com.sopt.cherrish.domain.userprocedure.fixture;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -12,6 +13,8 @@ public class UserProcedureTestFixture {
 
 	public static final LocalDateTime DEFAULT_SCHEDULED_AT = LocalDateTime.of(2025, 1, 1, 16, 0);
 	public static final String DEFAULT_SCHEDULED_AT_STRING = "2025-01-01T16:00:00";
+	public static final LocalDate DEFAULT_RECOVERY_TARGET_DATE = LocalDate.of(2025, 1, 10);
+	public static final String DEFAULT_RECOVERY_TARGET_DATE_STRING = "2025-01-10";
 
 	private UserProcedureTestFixture() {
 		// Utility class
@@ -20,6 +23,7 @@ public class UserProcedureTestFixture {
 	public static UserProcedureCreateRequestDto createValidRequest() {
 		return new UserProcedureCreateRequestDto(
 			DEFAULT_SCHEDULED_AT,
+			DEFAULT_RECOVERY_TARGET_DATE,
 			List.of(
 				new UserProcedureCreateRequestItemDto(1L, 6),
 				new UserProcedureCreateRequestItemDto(2L, 3)
@@ -30,6 +34,7 @@ public class UserProcedureTestFixture {
 	public static UserProcedureCreateRequestDto createRequestWithSingleProcedure(Long procedureId, Integer downtimeDays) {
 		return new UserProcedureCreateRequestDto(
 			DEFAULT_SCHEDULED_AT,
+			null,
 			List.of(new UserProcedureCreateRequestItemDto(procedureId, downtimeDays))
 		);
 	}
@@ -41,14 +46,16 @@ public class UserProcedureTestFixture {
 				1L,
 				"레이저 토닝",
 				DEFAULT_SCHEDULED_AT,
-				6
+				6,
+				DEFAULT_RECOVERY_TARGET_DATE
 			),
 			new UserProcedureResponseDto(
 				11L,
 				2L,
 				"필러",
 				DEFAULT_SCHEDULED_AT,
-				3
+				3,
+				DEFAULT_RECOVERY_TARGET_DATE
 			)
 		));
 	}

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/presentation/UserProcedureControllerTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/presentation/UserProcedureControllerTest.java
@@ -1,5 +1,6 @@
 package com.sopt.cherrish.domain.userprocedure.presentation;
 
+import static com.sopt.cherrish.domain.userprocedure.fixture.UserProcedureTestFixture.DEFAULT_RECOVERY_TARGET_DATE_STRING;
 import static com.sopt.cherrish.domain.userprocedure.fixture.UserProcedureTestFixture.DEFAULT_SCHEDULED_AT_STRING;
 import static com.sopt.cherrish.domain.userprocedure.fixture.UserProcedureTestFixture.createInvalidRequestMissingScheduledAt;
 import static com.sopt.cherrish.domain.userprocedure.fixture.UserProcedureTestFixture.createInvalidRequestWithEmptyProcedures;
@@ -76,12 +77,14 @@ class UserProcedureControllerTest {
 				.andExpect(jsonPath("$.data.procedures[0].procedureName").value("레이저 토닝"))
 				.andExpect(jsonPath("$.data.procedures[0].scheduledAt").value(DEFAULT_SCHEDULED_AT_STRING))
 				.andExpect(jsonPath("$.data.procedures[0].downtimeDays").value(6))
+				.andExpect(jsonPath("$.data.procedures[0].recoveryTargetDate").value(DEFAULT_RECOVERY_TARGET_DATE_STRING))
 				// 두 번째 시술 검증
 				.andExpect(jsonPath("$.data.procedures[1].userProcedureId").value(11))
 				.andExpect(jsonPath("$.data.procedures[1].procedureId").value(2))
 				.andExpect(jsonPath("$.data.procedures[1].procedureName").value("필러"))
 				.andExpect(jsonPath("$.data.procedures[1].scheduledAt").value(DEFAULT_SCHEDULED_AT_STRING))
-				.andExpect(jsonPath("$.data.procedures[1].downtimeDays").value(3));
+				.andExpect(jsonPath("$.data.procedures[1].downtimeDays").value(3))
+				.andExpect(jsonPath("$.data.procedures[1].recoveryTargetDate").value(DEFAULT_RECOVERY_TARGET_DATE_STRING));
 		}
 
 		@Test

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/UserProcedureCreateRequestDtoTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/UserProcedureCreateRequestDtoTest.java
@@ -2,6 +2,7 @@ package com.sopt.cherrish.domain.userprocedure.presentation.dto;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -25,6 +26,7 @@ class UserProcedureCreateRequestDtoTest {
 		// given
 		User user = UserFixture.createUser();
 		LocalDateTime scheduledAt = LocalDateTime.of(2025, 1, 15, 14, 30);
+		LocalDate recoveryTargetDate = LocalDate.of(2025, 1, 25);
 
 		Procedure procedure1 = ProcedureFixture.createProcedure("레이저 토닝", "레이저", 0, 1);
 		Procedure procedure2 = ProcedureFixture.createProcedure("필러", "주사", 1, 3);
@@ -32,6 +34,7 @@ class UserProcedureCreateRequestDtoTest {
 
 		UserProcedureCreateRequestDto request = new UserProcedureCreateRequestDto(
 			scheduledAt,
+			recoveryTargetDate,
 			List.of(
 				new UserProcedureCreateRequestItemDto(procedure1.getId(), 5),
 				new UserProcedureCreateRequestItemDto(procedure2.getId(), 7)
@@ -49,12 +52,14 @@ class UserProcedureCreateRequestDtoTest {
 		assertThat(result.get(0).getProcedure()).isEqualTo(procedure1);
 		assertThat(result.get(0).getScheduledAt()).isEqualTo(scheduledAt);
 		assertThat(result.get(0).getDowntimeDays()).isEqualTo(5);
+		assertThat(result.get(0).getRecoveryTargetDate()).isEqualTo(recoveryTargetDate);
 
 		// 두 번째 UserProcedure 검증
 		assertThat(result.get(1).getUser()).isEqualTo(user);
 		assertThat(result.get(1).getProcedure()).isEqualTo(procedure2);
 		assertThat(result.get(1).getScheduledAt()).isEqualTo(scheduledAt);
 		assertThat(result.get(1).getDowntimeDays()).isEqualTo(7);
+		assertThat(result.get(1).getRecoveryTargetDate()).isEqualTo(recoveryTargetDate);
 	}
 
 	@Test
@@ -66,6 +71,7 @@ class UserProcedureCreateRequestDtoTest {
 
 		UserProcedureCreateRequestDto request = new UserProcedureCreateRequestDto(
 			scheduledAt,
+			null,
 			List.of()
 		);
 

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/UserProcedureResponseDtoTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/presentation/dto/UserProcedureResponseDtoTest.java
@@ -2,6 +2,7 @@ package com.sopt.cherrish.domain.userprocedure.presentation.dto;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -27,13 +28,15 @@ class UserProcedureResponseDtoTest {
 		User user = UserFixture.createUser();
 		Procedure procedure = ProcedureFixture.createProcedure("레이저 토닝", "레이저", 0, 1);
 		LocalDateTime scheduledAt = LocalDateTime.of(2025, 1, 15, 14, 30);
+		LocalDate recoveryTargetDate = LocalDate.of(2025, 1, 20);
 
 		UserProcedure userProcedure = UserProcedureFixture.createUserProcedure(
 			10L,
 			user,
 			procedure,
 			scheduledAt,
-			5
+			5,
+			recoveryTargetDate
 		);
 
 		// when
@@ -45,6 +48,7 @@ class UserProcedureResponseDtoTest {
 		assertThat(result.procedureName()).isEqualTo("레이저 토닝");
 		assertThat(result.scheduledAt()).isEqualTo(scheduledAt);
 		assertThat(result.downtimeDays()).isEqualTo(5);
+		assertThat(result.recoveryTargetDate()).isEqualTo(recoveryTargetDate);
 	}
 
 	@Test
@@ -55,10 +59,11 @@ class UserProcedureResponseDtoTest {
 		Procedure procedure1 = ProcedureFixture.createProcedure("레이저 토닝", "레이저", 0, 1);
 		Procedure procedure2 = ProcedureFixture.createProcedure("필러", "주사", 1, 3);
 		LocalDateTime scheduledAt = LocalDateTime.of(2025, 1, 15, 14, 30);
+		LocalDate recoveryTargetDate = LocalDate.of(2025, 1, 20);
 
 		List<UserProcedure> userProcedures = List.of(
-			UserProcedureFixture.createUserProcedure(10L, user, procedure1, scheduledAt, 5),
-			UserProcedureFixture.createUserProcedure(11L, user, procedure2, scheduledAt, 7)
+			UserProcedureFixture.createUserProcedure(10L, user, procedure1, scheduledAt, 5, recoveryTargetDate),
+			UserProcedureFixture.createUserProcedure(11L, user, procedure2, scheduledAt, 7, recoveryTargetDate)
 		);
 
 		// when
@@ -73,6 +78,7 @@ class UserProcedureResponseDtoTest {
 		assertThat(result.procedures().get(0).procedureName()).isEqualTo("레이저 토닝");
 		assertThat(result.procedures().get(0).scheduledAt()).isEqualTo(scheduledAt);
 		assertThat(result.procedures().get(0).downtimeDays()).isEqualTo(5);
+		assertThat(result.procedures().get(0).recoveryTargetDate()).isEqualTo(recoveryTargetDate);
 
 		// 두 번째 항목 검증
 		assertThat(result.procedures().get(1).userProcedureId()).isEqualTo(11L);
@@ -80,5 +86,6 @@ class UserProcedureResponseDtoTest {
 		assertThat(result.procedures().get(1).procedureName()).isEqualTo("필러");
 		assertThat(result.procedures().get(1).scheduledAt()).isEqualTo(scheduledAt);
 		assertThat(result.procedures().get(1).downtimeDays()).isEqualTo(7);
+		assertThat(result.procedures().get(1).recoveryTargetDate()).isEqualTo(recoveryTargetDate);
 	}
 }


### PR DESCRIPTION
# 🛠 Related issue 🛠
- closed #115 

# ✏️ Work Description ✏️
- UserProcedure 도메인/DTO에 recoveryTargetDate 필드 추가
  - 요청/응답 DTO, 엔티티에 필드 반영 및 매핑 추가
- 다운타임 상세 응답에 recoveryTargetDate 포함
  - ProcedureEventDowntimeResponseDto에 필드 노출
- 관련 테스트 보강
  - UserProcedure/Calendar 테스트 및 픽스처에 필드 검증 추가

# 📸 Screenshot 📸
|              설명               |     사진      |
|:-----------------------------:|:-----------:|
| 시술 추가 | <img width="360" height="388" alt="스크린샷 2026-01-19 오후 11 59 08" src="https://github.com/user-attachments/assets/83055a41-33d5-4c52-8fc2-5e6777f0ae19" /> |
| 캘린더 다운타임 상세 조회 | <img width="325" height="353" alt="스크린샷 2026-01-19 오후 11 59 40" src="https://github.com/user-attachments/assets/f70775c3-b065-4341-9b46-e66067585366" /> |


# 😅 Uncompleted Tasks 😅
- 


# 📢 To Reviewers 📢
- 

