### PR TITLE
[Bug] 경로 없음 Error Handler 추가

### DIFF
--- a/src/main/java/com/sopt/cherrish/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sopt/cherrish/global/exception/GlobalExceptionHandler.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
@@ -112,6 +113,15 @@ public class GlobalExceptionHandler {
 	public CommonApiResponse<Void> handleOptimisticLockingFailure(ObjectOptimisticLockingFailureException e) {
 		log.warn("Optimistic locking failure: {}", e.getMessage());
 		return CommonApiResponse.fail(ErrorCode.CONCURRENT_UPDATE);
+	}
+
+	// 존재하지 않는 리소스 요청 처리
+	@ExceptionHandler(NoResourceFoundException.class)
+	@ResponseStatus(HttpStatus.NOT_FOUND)
+	public CommonApiResponse<Map<String, String>> handleNoResourceFound(NoResourceFoundException e) {
+		log.debug("Resource not found: {}", e.getResourcePath());
+		Map<String, String> details = Map.of("path", "/" + e.getResourcePath());
+		return CommonApiResponse.fail(ErrorCode.NOT_FOUND, details);
 	}
 
 	// 그 외 모든 예외 처리

--- a/src/main/java/com/sopt/cherrish/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sopt/cherrish/global/exception/GlobalExceptionHandler.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
@@ -112,6 +113,15 @@ public class GlobalExceptionHandler {
 	public CommonApiResponse<Void> handleOptimisticLockingFailure(ObjectOptimisticLockingFailureException e) {
 		log.warn("Optimistic locking failure: {}", e.getMessage());
 		return CommonApiResponse.fail(ErrorCode.CONCURRENT_UPDATE);
+	}
+
+	// 존재하지 않는 리소스 요청 처리
+	@ExceptionHandler(NoResourceFoundException.class)
+	@ResponseStatus(HttpStatus.NOT_FOUND)
+	public CommonApiResponse<Map<String, String>> handleNoResourceFound(NoResourceFoundException e) {
+		log.debug("Resource not found: {}", e.getResourcePath());
+		Map<String, String> details = Map.of("path", e.getResourcePath());
+		return CommonApiResponse.fail(ErrorCode.NOT_FOUND, details);
 	}
 
 	// 그 외 모든 예외 처리

--- a/src/main/java/com/sopt/cherrish/global/response/error/ErrorCode.java
+++ b/src/main/java/com/sopt/cherrish/global/response/error/ErrorCode.java
@@ -5,6 +5,7 @@ public enum ErrorCode implements ErrorType {
 	INVALID_INPUT("C001", "입력값이 올바르지 않습니다", 400),
 	INVALID_FORMAT("C002", "데이터 형식이 올바르지 않습니다", 400),
 	CONCURRENT_UPDATE("C003", "다른 사용자가 동시에 수정했습니다. 다시 시도해주세요.", 409),
+	NOT_FOUND("C004", "요청한 리소스를 찾을 수 없습니다", 404),
 
 	INTERNAL_SERVER_ERROR("C999", "서버 내부 오류가 발생했습니다", 500);
 


### PR DESCRIPTION
  # 🛠 Related issue 🛠
  - closed #118                                                                                                                                                                      
                                                                                                                                                                                                         
  # ✏️ Work Description ✏️
  - `NoResourceFoundException` 핸들러 추가
      - 스캔 봇 등 존재하지 않는 리소스 요청 시 별도 처리
      - 로그 레벨을 ERROR → DEBUG로 낮춰 불필요한 에러 로깅 방지
      - 요청 경로를 응답에 포함하여 디버깅 용이성 향상
  - `ErrorCode.NOT_FOUND` 추가
      - 404 응답용 공통 에러 코드 (C004)

  # 📸 Screenshot 📸
  |              설명               |     사진      |
  |:-----------------------------:|:-----------:|
  | 존재하지 않는 리소스 요청 시 응답 | `{"code":"C004","message":"요청한 리소스를 찾을 수 없습니다","data":{"path":"/+CSCOE+/logon_forms.js"}}` |

  # 😅 Uncompleted Tasks 😅
  - 없음

  # 📢 To Reviewers 📢
  - `log.debug` 사용으로 운영 환경에서는 로그가 출력되지 않을 수 있습니다. 필요 시 로그 레벨 조정 검토 부탁드립니다.

<img width="600" height="600" alt="image" src="https://github.com/user-attachments/assets/f46d3934-c8d8-4a66-a4b6-88f6445d3e19" />
