### PR TITLE
[Chore] DEMO 챌린지 챌린지가 끝나지 않는 버그 수정 DEPLOY

### DIFF
--- a/src/main/java/com/sopt/cherrish/domain/challenge/core/exception/ChallengeEndedException.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/core/exception/ChallengeEndedException.java
@@ -1,0 +1,12 @@
+package com.sopt.cherrish.domain.challenge.core.exception;
+
+/**
+ * 챌린지 종료 시 발생하는 예외
+ * 트랜잭션 커밋 후 예외를 던져야 하는 경우에 사용
+ */
+public class ChallengeEndedException extends ChallengeException {
+
+	public ChallengeEndedException() {
+		super(ChallengeErrorCode.CHALLENGE_NOT_FOUND);
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/challenge/demo/application/facade/DemoChallengeAdvanceDayFacade.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/demo/application/facade/DemoChallengeAdvanceDayFacade.java
@@ -1,18 +1,12 @@
 package com.sopt.cherrish.domain.challenge.demo.application.facade;
 
-import java.time.LocalDate;
-import java.util.List;
-
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.sopt.cherrish.domain.challenge.core.presentation.dto.response.ChallengeDetailResponseDto;
-import com.sopt.cherrish.domain.challenge.demo.application.service.DemoChallengeRoutineService;
 import com.sopt.cherrish.domain.challenge.demo.application.service.DemoChallengeService;
 import com.sopt.cherrish.domain.challenge.demo.application.service.DemoChallengeStatisticsService;
 import com.sopt.cherrish.domain.challenge.demo.domain.model.DemoChallenge;
-import com.sopt.cherrish.domain.challenge.demo.domain.model.DemoChallengeRoutine;
-import com.sopt.cherrish.domain.challenge.demo.domain.model.DemoChallengeStatistics;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,7 +17,6 @@ public class DemoChallengeAdvanceDayFacade {
 	private final DemoChallengeService challengeService;
 	private final DemoChallengeStatisticsService statisticsService;
 	private final DemoChallengeQueryFacade queryFacade;
-	private final DemoChallengeRoutineService routineService;
 
 	/**
 	 * 다음 날로 넘어가기 및 통계 재계산
@@ -46,25 +39,10 @@ public class DemoChallengeAdvanceDayFacade {
 		// 4. 챌린지 종료 여부에 따라 응답 생성
 		if (!challenge.getIsActive()) {
 			// 챌린지가 종료된 경우: 이미 조회한 challenge 객체로 응답 생성
-			return buildChallengeDetailResponse(challenge);
+			return queryFacade.buildChallengeDetailResponse(challenge);
 		}
 
 		// 챌린지가 계속 진행 중인 경우: QueryFacade 재사용
 		return queryFacade.getActiveChallengeDetail(userId);
-	}
-
-	private ChallengeDetailResponseDto buildChallengeDetailResponse(DemoChallenge challenge) {
-		LocalDate currentDate = challenge.getCurrentVirtualDate();
-		List<DemoChallengeRoutine> todayRoutines = routineService.getRoutinesByDate(challenge.getId(), currentDate);
-		DemoChallengeStatistics statistics = challenge.getStatistics();
-		int currentDay = challenge.getCurrentDay();
-
-		return ChallengeDetailResponseDto.from(
-			challenge,
-			currentDay,
-			statistics,
-			todayRoutines,
-			""
-		);
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/challenge/demo/application/facade/DemoChallengeAdvanceDayFacade.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/demo/application/facade/DemoChallengeAdvanceDayFacade.java
@@ -3,8 +3,7 @@ package com.sopt.cherrish.domain.challenge.demo.application.facade;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.sopt.cherrish.domain.challenge.core.exception.ChallengeErrorCode;
-import com.sopt.cherrish.domain.challenge.core.exception.ChallengeException;
+import com.sopt.cherrish.domain.challenge.core.exception.ChallengeEndedException;
 import com.sopt.cherrish.domain.challenge.core.presentation.dto.response.ChallengeDetailResponseDto;
 import com.sopt.cherrish.domain.challenge.demo.application.service.DemoChallengeService;
 import com.sopt.cherrish.domain.challenge.demo.application.service.DemoChallengeStatisticsService;
@@ -27,7 +26,7 @@ public class DemoChallengeAdvanceDayFacade {
 	 * 3. 통계 재계산
 	 * 4. 새 날짜의 챌린지 상세 정보 조회 및 반환
 	 */
-	@Transactional(noRollbackFor = ChallengeException.class)
+	@Transactional(noRollbackFor = ChallengeEndedException.class)
 	public ChallengeDetailResponseDto advanceDay(Long userId) {
 		// 1. 활성 챌린지 조회
 		DemoChallenge challenge = challengeService.getActiveChallengeWithStatistics(userId);
@@ -40,7 +39,7 @@ public class DemoChallengeAdvanceDayFacade {
 
 		// 4. 챌린지 종료 시 예외 발생 (트랜잭션은 커밋됨)
 		if (!challenge.getIsActive()) {
-			throw new ChallengeException(ChallengeErrorCode.CHALLENGE_NOT_FOUND);
+			throw new ChallengeEndedException();
 		}
 
 		// 챌린지가 계속 진행 중인 경우

--- a/src/main/java/com/sopt/cherrish/domain/challenge/demo/application/facade/DemoChallengeQueryFacade.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/demo/application/facade/DemoChallengeQueryFacade.java
@@ -27,26 +27,25 @@ public class DemoChallengeQueryFacade {
 	 */
 	@Transactional(readOnly = true)
 	public ChallengeDetailResponseDto getActiveChallengeDetail(Long userId) {
-		// 1. 활성 챌린지 조회 (통계와 함께 Fetch Join)
 		DemoChallenge challenge = challengeService.getActiveChallengeWithStatistics(userId);
+		return buildChallengeDetailResponse(challenge);
+	}
 
-		// 2. 가상 날짜 기준으로 오늘의 루틴 조회
+	/**
+	 * 챌린지 상세 응답 DTO 생성
+	 */
+	public ChallengeDetailResponseDto buildChallengeDetailResponse(DemoChallenge challenge) {
 		LocalDate currentDate = challenge.getCurrentVirtualDate();
 		List<DemoChallengeRoutine> todayRoutines = routineService.getRoutinesByDate(challenge.getId(), currentDate);
-
-		// 3. 통계는 Challenge에서 가져옴 (이미 Fetch Join으로 로드됨)
 		DemoChallengeStatistics statistics = challenge.getStatistics();
-
-		// 4. 현재 일차 계산
 		int currentDay = challenge.getCurrentDay();
 
-		// 5. 응답 DTO 생성
 		return ChallengeDetailResponseDto.from(
 			challenge,
 			currentDay,
 			statistics,
 			todayRoutines,
-			""  // 응원 메시지 없음
+			""
 		);
 	}
 }


### PR DESCRIPTION
  # 🛠 Related issue 🛠
  - closed #122                                                                                                                                                                                          
                                                                                                                                                                                                         
  # ✏️ Work Description ✏️
  - 데모 챌린지 종료 버그 수정
      - `advanceDay()` 호출 시 종료일을 넘으면 `isActive=false`가 DB에 반영되지 않던 버그 수정
      - 원인: 챌린지 종료 후 `getActiveChallengeDetail()`이 `isActive=true`인 챌린지만 조회하여 예외 발생 → 트랜잭션 롤백
      - 해결: `ChallengeEndedException` 전용 예외 생성 및 `@Transactional(noRollbackFor = ChallengeEndedException.class)` 적용
  - 챌린지 종료 시 응답 처리 개선
      - 챌린지가 종료되면 `ChallengeEndedException`을 던져 클라이언트에 종료 상태 전달 (CHALLENGE_NOT_FOUND 응답)
  - 중복 코드 리팩토링
      - `DemoChallengeQueryFacade`에 `buildChallengeDetailResponse()` 공통 메서드 추출
      - `DemoChallengeAdvanceDayFacade`에서 중복 코드 제거 및 재사용

  # 😅 Uncompleted Tasks 😅
  - 없음

  # 📢 To Reviewers 📢
  - `ChallengeEndedException`은 `ChallengeException`을 상속하여 기존 예외 처리 로직과 호환됩니다.
  - `noRollbackFor`를 `ChallengeEndedException`으로 제한하여 `statisticsService.recalculateStatistics()` 등에서 발생하는 다른 `ChallengeException`은 정상적으로 롤백됩니다.