### PR TITLE
[Bug] 챌린지 75 ~ 100 구간 남은 루틴 계산 로직 추가

### DIFF
--- a/src/main/java/com/sopt/cherrish/domain/challenge/demo/domain/model/DemoChallengeStatistics.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/demo/domain/model/DemoChallengeStatistics.java
@@ -130,16 +130,14 @@ public class DemoChallengeStatistics extends BaseTimeEntity {
 
 	/**
 	 * 다음 레벨까지 남은 루틴 개수 계산
+	 * 레벨 4일 때는 100%까지 남은 루틴 개수를 반환
 	 */
 	public int getRemainingRoutinesToNextLevel() {
-		if (cherryLevel >= 4) {
-			return 0;
-		}
-
 		double nextThreshold = switch (cherryLevel) {
 			case 1 -> LEVEL_2_THRESHOLD;
 			case 2 -> LEVEL_3_THRESHOLD;
 			case 3 -> LEVEL_4_THRESHOLD;
+			case 4 -> 100.0;
 			default -> 100.0;
 		};
 

--- a/src/main/java/com/sopt/cherrish/domain/challenge/demo/domain/model/DemoChallengeStatistics.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/demo/domain/model/DemoChallengeStatistics.java
@@ -137,7 +137,6 @@ public class DemoChallengeStatistics extends BaseTimeEntity {
 			case 1 -> LEVEL_2_THRESHOLD;
 			case 2 -> LEVEL_3_THRESHOLD;
 			case 3 -> LEVEL_4_THRESHOLD;
-			case 4 -> 100.0;
 			default -> 100.0;
 		};
 


### PR DESCRIPTION
# 🛠 Related issue 🛠                                                                                                                                                                                    

- closed #134                                                                                                                                                                                          
                                                                                                                                                                                                           # ✏️ Work Description ✏️
  - 다음 레벨까지 남은 루틴 개수 계산 로직 수정                                                                                                                                                          
      - 기존: 레벨 4(75% 이상)일 때 남은 루틴 개수가 0으로 반환됨                                                                                                                                        
      - 수정: 레벨 4일 때 100%까지 남은 루틴 개수를 계산하여 반환
      - `cherryLevel >= 4` 조건문 제거 및 switch문에서 default로 100.0 처리

  # 📸 Screenshot 📸
  |              설명               |     사진      |
  |:-----------------------------:|:-----------:|
  |        75% 이상일 때 남은 루틴 개수 확인      | <img width="1663" height="847" alt="image" src="https://github.com/user-attachments/assets/6987a6e1-de39-4a93-bcf2-26af6732c7d1" /> |

  # 😅 Uncompleted Tasks 😅
  - 없음

  # 📢 To Reviewers 📢
  - `DemoChallengeStatistics.getRemainingRoutinesToNextLevel()` 메서드의 로직 변경 확인 부탁드립니다
  - 기존에는 75%부터 0개로 표시되던 것을 100%까지 남은 개수로 계산하도록 수정했습니다