### PR TITLE
[Enhancement] 체리 레벨 0~4로 변경

### DIFF
--- a/src/main/java/com/sopt/cherrish/domain/challenge/core/domain/model/CherryLevel.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/core/domain/model/CherryLevel.java
@@ -35,6 +35,7 @@ public enum CherryLevel {
 	 * 레벨 숫자로 CherryLevel 찾기
 	 *
 	 * @param level 체리 레벨 (1-4)
+	 *              데모용으로 현재 (0-4)
 	 * @return 해당하는 CherryLevel enum
 	 * @throws ChallengeException 존재하지 않는 레벨인 경우
 	 */

--- a/src/main/java/com/sopt/cherrish/domain/challenge/core/domain/model/CherryLevel.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/core/domain/model/CherryLevel.java
@@ -18,7 +18,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum CherryLevel {
 
-	LEVEL_1(1, "몽롱체리"),    // 0-24%
+	LEVEL_0(0, "몽롱체리"),    // completedCount == 0
+	LEVEL_1(1, "몽롱체리"),    // 1개 이상, 0-24%
 	LEVEL_2(2, "뽀득체리"),    // 25-49%
 	LEVEL_3(3, "팡팡체리"),    // 50-74%
 	LEVEL_4(4, "꾸꾸체리");    // 75-100%

--- a/src/main/java/com/sopt/cherrish/domain/challenge/core/exception/ChallengeErrorCode.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/core/exception/ChallengeErrorCode.java
@@ -20,7 +20,7 @@ public enum ChallengeErrorCode implements ErrorType {
 	DUPLICATE_ROUTINE_IDS("CH009", "중복된 루틴 ID가 포함되어 있습니다", 400),
 	CHALLENGE_NOT_ACTIVE("CH010", "비활성 챌린지에는 루틴을 추가할 수 없습니다", 400),
 	CUSTOM_ROUTINE_LIMIT_EXCEEDED("CH011", "최대로 추가할 수 있는 루틴은 20개입니다", 400),
-	INVALID_CHERRY_LEVEL("CH012", "유효하지 않은 체리 레벨입니다 (1-4)", 400);
+	INVALID_CHERRY_LEVEL("CH012", "유효하지 않은 체리 레벨입니다 (0-4)", 400);
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/sopt/cherrish/domain/challenge/demo/domain/model/DemoChallengeStatistics.java
+++ b/src/main/java/com/sopt/cherrish/domain/challenge/demo/domain/model/DemoChallengeStatistics.java
@@ -47,14 +47,14 @@ public class DemoChallengeStatistics extends BaseTimeEntity {
 	private Integer totalRoutineCount;
 
 	@Column(nullable = false, name = "cherry_level")
-	private Integer cherryLevel = 1;
+	private Integer cherryLevel = 0;
 
 	@Builder
 	private DemoChallengeStatistics(DemoChallenge demoChallenge, Integer totalRoutineCount) {
 		this.demoChallenge = demoChallenge;
 		this.completedCount = 0;
 		this.totalRoutineCount = totalRoutineCount;
-		this.cherryLevel = 1;
+		this.cherryLevel = 0;
 	}
 
 	/**
@@ -86,10 +86,15 @@ public class DemoChallengeStatistics extends BaseTimeEntity {
 
 	/**
 	 * 완료 진행률 기반 체리 레벨 계산
+	 * - 레벨 0: completedCount == 0 (몽롱체리)
+	 * - 레벨 1: 1개 이상, 0% ~ 24.99%
+	 * - 레벨 2: 25% ~ 49.99%
+	 * - 레벨 3: 50% ~ 74.99%
+	 * - 레벨 4: 75% ~ 100%
 	 */
 	public int calculateCherryLevel() {
-		if (totalRoutineCount == 0) {
-			return 1;
+		if (completedCount == 0) {
+			return 0;
 		}
 
 		double progressPercentage = getProgressPercentage();
@@ -110,7 +115,7 @@ public class DemoChallengeStatistics extends BaseTimeEntity {
 	 * 현재 레벨 구간 내에서의 진척도 계산 (0-100%)
 	 */
 	public double getProgressToNextLevel() {
-		if (totalRoutineCount == 0) {
+		if (totalRoutineCount == 0 || completedCount == 0) {
 			return 0.0;
 		}
 
@@ -130,11 +135,12 @@ public class DemoChallengeStatistics extends BaseTimeEntity {
 
 	/**
 	 * 다음 레벨까지 남은 루틴 개수 계산
+	 * 레벨 0, 1일 때는 레벨 2(25%)까지 남은 개수 반환
 	 * 레벨 4일 때는 100%까지 남은 루틴 개수를 반환
 	 */
 	public int getRemainingRoutinesToNextLevel() {
 		double nextThreshold = switch (cherryLevel) {
-			case 1 -> LEVEL_2_THRESHOLD;
+			case 0, 1 -> LEVEL_2_THRESHOLD;
 			case 2 -> LEVEL_3_THRESHOLD;
 			case 3 -> LEVEL_4_THRESHOLD;
 			default -> 100.0;


### PR DESCRIPTION
  # 🛠 Related issue 🛠                                                                                                                                                                                  
  - closed #140

  # ✏️ Work Description ✏️
  - 데모 챌린지 체리 레벨 로직 변경
      - completedCount가 0개일 때 레벨 0(몽롱체리)으로 반환
      - 1개 이상 완료 시 기존 레벨 구간(1~4) 적용
  - CherryLevel enum 수정
      - LEVEL_0(0, "몽롱체리") 추가
      - 레벨 0, 1 모두 "몽롱체리" 이름 사용
  - DemoChallengeStatistics 수정
      - `calculateCherryLevel()`: completedCount == 0이면 레벨 0 반환
      - `getProgressToNextLevel()`: completedCount == 0이면 0.0 반환
      - `getRemainingRoutinesToNextLevel()`: 레벨 0, 1 모두 레벨 2(25%)까지 남은 개수 반환
      - 초기 cherryLevel 값 1 → 0으로 변경

  # 📸 Screenshot 📸
  | 설명 | 사진 |
  |:---:|:---:|
  | 루틴 0개 완료 시 (레벨 0) | <img width="1678" height="985" alt="image" src="https://github.com/user-attachments/assets/510241bc-f8b2-47ed-a701-304d4cee518e" /> |
  | 루틴 1개 이상 완료 시 (레벨 1~4) | <img width="1704" height="829" alt="image" src="https://github.com/user-attachments/assets/85433d8f-8c12-4b95-8fca-aca723494b27" /> |

  # 😅 Uncompleted Tasks 😅
  - 없음

  # 📢 To Reviewers 📢
  - 레벨 구간 정리
    | completedCount | 진행률 | 레벨 | 이름 |
    |:---:|:---:|:---:|:---:|
    | 0 | - | 0 | 몽롱체리 |
    | 1개 이상 | 0~24% | 1 | 몽롱체리 |
    | - | 25~49% | 2 | 뽀득체리 |
    | - | 50~74% | 3 | 팡팡체리 |
    | - | 75~100% | 4 | 꾸꾸체리 |
  - **demo 패키지에만 적용**되었습니다 (core는 기존 로직 유지)