### PR TITLE
[Feature] SpringSecurity 및 소셜로그인 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,8 @@ REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_PASSWORD=
 
-# JWT Configuration
-JWT_SECRET_KEY=your-256-bit-secret-key-here
+# JWT Configuration (Base64-encoded 32+ bytes; e.g., openssl rand -base64 32)
+JWT_SECRET_KEY=MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=
 
 # Social Login Configuration
 APPLE_CLIENT_ID=your-apple-bundle-id

--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,14 @@
-# Database Configuration
+프롲# Database Configuration
 DB_HOST=localhost
 DB_PORT=5432
 DB_NAME=cherrish
 DB_USERNAME=postgres
 DB_PASSWORD=postgres
+
+# Redis Configuration (로컬 개발 환경 - 인증 없음)
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_PASSWORD=
 
 # OpenAI Configuration
 OPENAI_API_KEY=sk-proj-your-api-key-here

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-프롲# Database Configuration
+# Database Configuration
 DB_HOST=localhost
 DB_PORT=5432
 DB_NAME=cherrish

--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,12 @@ REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_PASSWORD=
 
+# JWT Configuration
+JWT_SECRET_KEY=your-256-bit-secret-key-here
+
+# Social Login Configuration
+APPLE_CLIENT_ID=your-apple-bundle-id
+
 # OpenAI Configuration
 OPENAI_API_KEY=sk-proj-your-api-key-here
 OPENAI_MODEL=gpt-3.5-turbo

--- a/build.gradle
+++ b/build.gradle
@@ -46,9 +46,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 
 	// JWT
-	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.7'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.7'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.7'
 
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,16 @@ dependencies {
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
-	//Spring Security
+	// Spring Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	//swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+	//Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 	//swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
 	implementation 'io.swagger.core.v3:swagger-annotations-jakarta:2.2.41'

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -16,5 +16,19 @@ services:
       timeout: 5s
       retries: 5
 
+  redis:
+    image: redis:7-alpine
+    container_name: cherrish-redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
 volumes:
   postgres_data:
+  redis_data:

--- a/scripts/deploy-dev.sh
+++ b/scripts/deploy-dev.sh
@@ -32,6 +32,11 @@ OPENAI_API_KEY=$(aws ssm get-parameter --name "/cherrish/OPENAI_API_KEY" --regio
 OPENAI_MODEL=$(aws ssm get-parameter --name "/cherrish/OPENAI_MODEL" --region "${AWS_REGION}" --query "Parameter.Value" --output text)
 SERVER_URL=$(aws ssm get-parameter --name "/cherrish/SERVER_URL" --region "${AWS_REGION}" --query "Parameter.Value" --output text)
 DISCORD_ERROR_WEBHOOK_URL=$(aws ssm get-parameter --name "/cherrish/DISCORD_ERROR_WEBHOOK_URL" --region "${AWS_REGION}" --with-decryption --query "Parameter.Value" --output text)
+REDIS_HOST=$(aws ssm get-parameter --name "/cherrish/REDIS_HOST" --region "${AWS_REGION}" --query "Parameter.Value" --output text)
+REDIS_PORT=$(aws ssm get-parameter --name "/cherrish/REDIS_PORT" --region "${AWS_REGION}" --query "Parameter.Value" --output text)
+REDIS_PASSWORD=$(aws ssm get-parameter --name "/cherrish/REDIS_PASSWORD" --region "${AWS_REGION}" --with-decryption --query "Parameter.Value" --output text)
+JWT_SECRET_KEY=$(aws ssm get-parameter --name "/cherrish/JWT_SECRET_KEY" --region "${AWS_REGION}" --with-decryption --query "Parameter.Value" --output text)
+APPLE_CLIENT_ID=$(aws ssm get-parameter --name "/cherrish/APPLE_CLIENT_ID" --region "${AWS_REGION}" --query "Parameter.Value" --output text)
 
 # Stop and remove existing container
 echo "Stopping existing container..."
@@ -53,6 +58,11 @@ docker run -d \
   -e OPENAI_MODEL="${OPENAI_MODEL}" \
   -e SERVER_URL="${SERVER_URL}" \
   -e DISCORD_ERROR_WEBHOOK_URL="${DISCORD_ERROR_WEBHOOK_URL}" \
+  -e REDIS_HOST="${REDIS_HOST}" \
+  -e REDIS_PORT="${REDIS_PORT}" \
+  -e REDIS_PASSWORD="${REDIS_PASSWORD}" \
+  -e JWT_SECRET_KEY="${JWT_SECRET_KEY}" \
+  -e APPLE_CLIENT_ID="${APPLE_CLIENT_ID}" \
   "${IMAGE}"
 
 # Cleanup old images

--- a/src/main/java/com/sopt/cherrish/domain/auth/application/service/AuthService.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/application/service/AuthService.java
@@ -1,0 +1,114 @@
+package com.sopt.cherrish.domain.auth.application.service;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sopt.cherrish.domain.auth.domain.repository.RefreshTokenRepository;
+import com.sopt.cherrish.domain.auth.exception.AuthErrorCode;
+import com.sopt.cherrish.domain.auth.exception.AuthException;
+import com.sopt.cherrish.domain.auth.infrastructure.jwt.JwtTokenProvider;
+import com.sopt.cherrish.domain.auth.infrastructure.social.SocialUserInfo;
+import com.sopt.cherrish.domain.auth.presentation.dto.request.SocialLoginRequestDto;
+import com.sopt.cherrish.domain.auth.presentation.dto.request.TokenRefreshRequestDto;
+import com.sopt.cherrish.domain.auth.presentation.dto.response.LoginResponseDto;
+import com.sopt.cherrish.domain.auth.presentation.dto.response.TokenResponseDto;
+import com.sopt.cherrish.domain.user.domain.model.User;
+import com.sopt.cherrish.domain.user.domain.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+	private static final String DEFAULT_NAME = "사용자";
+	private static final int DEFAULT_AGE = 0;
+
+	private final SocialLoginService socialLoginService;
+	private final UserRepository userRepository;
+	private final JwtTokenProvider jwtTokenProvider;
+	private final RefreshTokenRepository refreshTokenRepository;
+
+	@Transactional
+	public LoginResponseDto login(SocialLoginRequestDto request) {
+		SocialUserInfo socialUserInfo = socialLoginService.authenticate(
+			request.provider(),
+			request.token()
+		);
+
+		Optional<User> existingUser = userRepository.findBySocialProviderAndSocialId(
+			request.provider(),
+			socialUserInfo.socialId()
+		);
+
+		boolean isNewUser = existingUser.isEmpty();
+		User user;
+
+		if (isNewUser) {
+			user = User.builder()
+				.name(DEFAULT_NAME)
+				.age(DEFAULT_AGE)
+				.socialProvider(request.provider())
+				.socialId(socialUserInfo.socialId())
+				.email(socialUserInfo.email())
+				.build();
+			user = userRepository.save(user);
+		} else {
+			user = existingUser.get();
+		}
+
+		String accessToken = jwtTokenProvider.createAccessToken(user.getId());
+		String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+
+		refreshTokenRepository.save(
+			user.getId(),
+			refreshToken,
+			jwtTokenProvider.getRefreshTokenExpiration()
+		);
+
+		return new LoginResponseDto(user.getId(), isNewUser, accessToken, refreshToken);
+	}
+
+	@Transactional
+	public TokenResponseDto refresh(TokenRefreshRequestDto request) {
+		String refreshToken = request.refreshToken();
+
+		jwtTokenProvider.validateToken(refreshToken);
+
+		if (!jwtTokenProvider.isRefreshToken(refreshToken)) {
+			throw new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+		}
+
+		Long userId = jwtTokenProvider.getUserId(refreshToken);
+
+		if (!userRepository.existsById(userId)) {
+			throw new AuthException(AuthErrorCode.USER_NOT_FOUND);
+		}
+
+		String storedToken = refreshTokenRepository.findByUserId(userId)
+			.orElseThrow(() -> new AuthException(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND));
+
+		if (!storedToken.equals(refreshToken)) {
+			throw new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+		}
+
+		String newAccessToken = jwtTokenProvider.createAccessToken(userId);
+		String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
+
+		refreshTokenRepository.save(
+			userId,
+			newRefreshToken,
+			jwtTokenProvider.getRefreshTokenExpiration()
+		);
+
+		return new TokenResponseDto(newAccessToken, newRefreshToken);
+	}
+
+	@Transactional
+	public void logout(Long userId) {
+		refreshTokenRepository.deleteByUserId(userId);
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/auth/application/service/AuthService.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/application/service/AuthService.java
@@ -1,5 +1,7 @@
 package com.sopt.cherrish.domain.auth.application.service;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
@@ -110,7 +112,7 @@ public class AuthService {
 		String storedToken = refreshTokenRepository.findByUserId(userId)
 			.orElseThrow(() -> new AuthException(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND));
 
-		if (!storedToken.equals(refreshToken)) {
+		if (!constantTimeEquals(storedToken, refreshToken)) {
 			throw new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN);
 		}
 
@@ -148,5 +150,15 @@ public class AuthService {
 		);
 
 		return new TokenResponseDto(accessToken, refreshToken);
+	}
+
+	private boolean constantTimeEquals(String a, String b) {
+		if (a == null || b == null) {
+			return false;
+		}
+		return MessageDigest.isEqual(
+			a.getBytes(StandardCharsets.UTF_8),
+			b.getBytes(StandardCharsets.UTF_8)
+		);
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/auth/application/service/SocialLoginService.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/application/service/SocialLoginService.java
@@ -9,6 +9,11 @@ import com.sopt.cherrish.domain.auth.infrastructure.social.SocialUserInfo;
 
 import lombok.RequiredArgsConstructor;
 
+/**
+ * 소셜 로그인 인증을 처리하는 서비스.
+ *
+ * <p>소셜 플랫폼에 따라 적절한 인증 클라이언트를 선택하여 토큰을 검증합니다.</p>
+ */
 @Service
 @RequiredArgsConstructor
 public class SocialLoginService {
@@ -16,6 +21,14 @@ public class SocialLoginService {
 	private final KakaoAuthClient kakaoAuthClient;
 	private final AppleAuthClient appleAuthClient;
 
+	/**
+	 * 소셜 토큰을 검증하고 사용자 정보를 반환합니다.
+	 *
+	 * @param provider 소셜 플랫폼 (KAKAO, APPLE)
+	 * @param token 소셜 플랫폼에서 발급한 토큰
+	 * @return 소셜 사용자 정보
+	 * @throws com.sopt.cherrish.domain.auth.exception.AuthException 토큰이 유효하지 않은 경우
+	 */
 	public SocialUserInfo authenticate(SocialProvider provider, String token) {
 		return switch (provider) {
 			case KAKAO -> kakaoAuthClient.getUserInfo(token);

--- a/src/main/java/com/sopt/cherrish/domain/auth/application/service/SocialLoginService.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/application/service/SocialLoginService.java
@@ -1,0 +1,25 @@
+package com.sopt.cherrish.domain.auth.application.service;
+
+import org.springframework.stereotype.Service;
+
+import com.sopt.cherrish.domain.auth.domain.model.SocialProvider;
+import com.sopt.cherrish.domain.auth.infrastructure.social.AppleAuthClient;
+import com.sopt.cherrish.domain.auth.infrastructure.social.KakaoAuthClient;
+import com.sopt.cherrish.domain.auth.infrastructure.social.SocialUserInfo;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SocialLoginService {
+
+	private final KakaoAuthClient kakaoAuthClient;
+	private final AppleAuthClient appleAuthClient;
+
+	public SocialUserInfo authenticate(SocialProvider provider, String token) {
+		return switch (provider) {
+			case KAKAO -> kakaoAuthClient.getUserInfo(token);
+			case APPLE -> appleAuthClient.getUserInfo(token);
+		};
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/auth/domain/model/SocialProvider.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/domain/model/SocialProvider.java
@@ -1,0 +1,6 @@
+package com.sopt.cherrish.domain.auth.domain.model;
+
+public enum SocialProvider {
+	KAKAO,
+	APPLE
+}

--- a/src/main/java/com/sopt/cherrish/domain/auth/domain/repository/AccessTokenBlacklistRepository.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/domain/repository/AccessTokenBlacklistRepository.java
@@ -38,8 +38,10 @@ public class AccessTokenBlacklistRepository {
 	/**
 	 * Access Token이 블랙리스트에 있는지 확인합니다.
 	 *
+	 * <p>Redis 연결 문제 등으로 null이 반환될 수 있으므로 null-safe 비교를 수행합니다.</p>
+	 *
 	 * @param token 확인할 Access Token
-	 * @return 블랙리스트에 있으면 true
+	 * @return 블랙리스트에 있으면 true, 없거나 확인 불가 시 false
 	 */
 	public boolean isBlacklisted(String token) {
 		String key = KEY_PREFIX + token;

--- a/src/main/java/com/sopt/cherrish/domain/auth/domain/repository/AccessTokenBlacklistRepository.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/domain/repository/AccessTokenBlacklistRepository.java
@@ -43,6 +43,6 @@ public class AccessTokenBlacklistRepository {
 	 */
 	public boolean isBlacklisted(String token) {
 		String key = KEY_PREFIX + token;
-		return redisTemplate.hasKey(key);
+		return Boolean.TRUE.equals(redisTemplate.hasKey(key));
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/auth/domain/repository/AccessTokenBlacklistRepository.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/domain/repository/AccessTokenBlacklistRepository.java
@@ -1,0 +1,48 @@
+package com.sopt.cherrish.domain.auth.domain.repository;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Access Token 블랙리스트를 Redis에 관리하는 저장소.
+ *
+ * <p>로그아웃된 Access Token을 저장하여 만료 전까지 재사용을 방지합니다.
+ * TTL은 토큰의 남은 만료 시간으로 설정되어 자동으로 정리됩니다.</p>
+ */
+@Repository
+@RequiredArgsConstructor
+public class AccessTokenBlacklistRepository {
+
+	private static final String KEY_PREFIX = "blacklist:";
+
+	private final RedisTemplate<String, String> redisTemplate;
+
+	/**
+	 * Access Token을 블랙리스트에 추가합니다.
+	 *
+	 * @param token 블랙리스트에 추가할 Access Token
+	 * @param expirationMillis 토큰의 남은 만료 시간 (밀리초)
+	 */
+	public void add(String token, long expirationMillis) {
+		if (expirationMillis <= 0) {
+			return;
+		}
+		String key = KEY_PREFIX + token;
+		redisTemplate.opsForValue().set(key, "blacklisted", expirationMillis, TimeUnit.MILLISECONDS);
+	}
+
+	/**
+	 * Access Token이 블랙리스트에 있는지 확인합니다.
+	 *
+	 * @param token 확인할 Access Token
+	 * @return 블랙리스트에 있으면 true
+	 */
+	public boolean isBlacklisted(String token) {
+		String key = KEY_PREFIX + token;
+		return redisTemplate.hasKey(key);
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/auth/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/domain/repository/RefreshTokenRepository.java
@@ -8,6 +8,12 @@ import org.springframework.stereotype.Repository;
 
 import lombok.RequiredArgsConstructor;
 
+/**
+ * Refresh Token을 Redis에 저장하고 관리하는 저장소.
+ *
+ * <p>사용자별로 하나의 Refresh Token만 유효하도록 관리합니다.
+ * TTL이 설정되어 만료된 토큰은 자동으로 삭제됩니다.</p>
+ */
 @Repository
 @RequiredArgsConstructor
 public class RefreshTokenRepository {
@@ -16,22 +22,50 @@ public class RefreshTokenRepository {
 
 	private final RedisTemplate<String, String> redisTemplate;
 
+	/**
+	 * Refresh Token을 저장합니다.
+	 *
+	 * <p>기존에 저장된 토큰이 있으면 덮어씁니다.</p>
+	 *
+	 * @param userId 사용자 ID
+	 * @param refreshToken 저장할 Refresh Token
+	 * @param expirationMillis 만료 시간 (밀리초)
+	 */
 	public void save(Long userId, String refreshToken, long expirationMillis) {
 		String key = KEY_PREFIX + userId;
 		redisTemplate.opsForValue().set(key, refreshToken, expirationMillis, TimeUnit.MILLISECONDS);
 	}
 
+	/**
+	 * 사용자의 Refresh Token을 조회합니다.
+	 *
+	 * @param userId 사용자 ID
+	 * @return 저장된 Refresh Token, 없으면 빈 Optional
+	 */
 	public Optional<String> findByUserId(Long userId) {
 		String key = KEY_PREFIX + userId;
 		String token = redisTemplate.opsForValue().get(key);
 		return Optional.ofNullable(token);
 	}
 
+	/**
+	 * 사용자의 Refresh Token을 삭제합니다.
+	 *
+	 * <p>로그아웃 시 호출되어 해당 토큰을 무효화합니다.</p>
+	 *
+	 * @param userId 사용자 ID
+	 */
 	public void deleteByUserId(Long userId) {
 		String key = KEY_PREFIX + userId;
 		redisTemplate.delete(key);
 	}
 
+	/**
+	 * 사용자의 Refresh Token 존재 여부를 확인합니다.
+	 *
+	 * @param userId 사용자 ID
+	 * @return 토큰이 존재하면 true
+	 */
 	public boolean existsByUserId(Long userId) {
 		String key = KEY_PREFIX + userId;
 		return redisTemplate.hasKey(key);

--- a/src/main/java/com/sopt/cherrish/domain/auth/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/domain/repository/RefreshTokenRepository.java
@@ -1,0 +1,39 @@
+package com.sopt.cherrish.domain.auth.domain.repository;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRepository {
+
+	private static final String KEY_PREFIX = "refresh_token:";
+
+	private final RedisTemplate<String, String> redisTemplate;
+
+	public void save(Long userId, String refreshToken, long expirationMillis) {
+		String key = KEY_PREFIX + userId;
+		redisTemplate.opsForValue().set(key, refreshToken, expirationMillis, TimeUnit.MILLISECONDS);
+	}
+
+	public Optional<String> findByUserId(Long userId) {
+		String key = KEY_PREFIX + userId;
+		String token = redisTemplate.opsForValue().get(key);
+		return Optional.ofNullable(token);
+	}
+
+	public void deleteByUserId(Long userId) {
+		String key = KEY_PREFIX + userId;
+		redisTemplate.delete(key);
+	}
+
+	public boolean existsByUserId(Long userId) {
+		String key = KEY_PREFIX + userId;
+		return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/auth/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/domain/repository/RefreshTokenRepository.java
@@ -25,13 +25,17 @@ public class RefreshTokenRepository {
 	/**
 	 * Refresh Token을 저장합니다.
 	 *
-	 * <p>기존에 저장된 토큰이 있으면 덮어씁니다.</p>
+	 * <p>기존에 저장된 토큰이 있으면 덮어씁니다.
+	 * 만료 시간이 0 이하인 경우 저장하지 않습니다.</p>
 	 *
 	 * @param userId 사용자 ID
 	 * @param refreshToken 저장할 Refresh Token
 	 * @param expirationMillis 만료 시간 (밀리초)
 	 */
 	public void save(Long userId, String refreshToken, long expirationMillis) {
+		if (expirationMillis <= 0) {
+			return;
+		}
 		String key = KEY_PREFIX + userId;
 		redisTemplate.opsForValue().set(key, refreshToken, expirationMillis, TimeUnit.MILLISECONDS);
 	}
@@ -63,11 +67,13 @@ public class RefreshTokenRepository {
 	/**
 	 * 사용자의 Refresh Token 존재 여부를 확인합니다.
 	 *
+	 * <p>Redis 연결 문제 등으로 null이 반환될 수 있으므로 null-safe 비교를 수행합니다.</p>
+	 *
 	 * @param userId 사용자 ID
-	 * @return 토큰이 존재하면 true
+	 * @return 토큰이 존재하면 true, 없거나 확인 불가 시 false
 	 */
 	public boolean existsByUserId(Long userId) {
 		String key = KEY_PREFIX + userId;
-		return redisTemplate.hasKey(key);
+		return Boolean.TRUE.equals(redisTemplate.hasKey(key));
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/auth/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/domain/repository/RefreshTokenRepository.java
@@ -34,6 +34,6 @@ public class RefreshTokenRepository {
 
 	public boolean existsByUserId(Long userId) {
 		String key = KEY_PREFIX + userId;
-		return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+		return redisTemplate.hasKey(key);
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/exception/AuthErrorCode.java
@@ -1,0 +1,28 @@
+package com.sopt.cherrish.domain.auth.exception;
+
+import com.sopt.cherrish.global.response.error.ErrorType;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorType {
+
+	UNAUTHORIZED("A001", "인증이 필요합니다", 401),
+	INVALID_TOKEN("A002", "유효하지 않은 토큰입니다", 401),
+	TOKEN_EXPIRED("A003", "만료된 토큰입니다", 401),
+	ACCESS_DENIED("A004", "접근 권한이 없습니다", 403),
+	USER_NOT_FOUND("A005", "사용자를 찾을 수 없습니다", 404),
+
+	INVALID_SOCIAL_TOKEN("A010", "유효하지 않은 소셜 토큰입니다", 401),
+	SOCIAL_AUTH_FAILED("A011", "소셜 인증에 실패했습니다", 401),
+	UNSUPPORTED_SOCIAL_PROVIDER("A012", "지원하지 않는 소셜 로그인 제공자입니다", 400),
+
+	INVALID_REFRESH_TOKEN("A020", "유효하지 않은 리프레시 토큰입니다", 401),
+	REFRESH_TOKEN_NOT_FOUND("A021", "리프레시 토큰이 존재하지 않습니다", 401);
+
+	private final String code;
+	private final String message;
+	private final int status;
+}

--- a/src/main/java/com/sopt/cherrish/domain/auth/exception/AuthException.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/exception/AuthException.java
@@ -1,0 +1,10 @@
+package com.sopt.cherrish.domain.auth.exception;
+
+import com.sopt.cherrish.global.exception.BaseException;
+
+public class AuthException extends BaseException {
+
+	public AuthException(AuthErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtAuthenticationFilter.java
@@ -34,7 +34,6 @@ import lombok.extern.slf4j.Slf4j;
  * 401 응답을 반환합니다.</p>
  */
 @Slf4j
-@Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 

--- a/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtAuthenticationFilter.java
@@ -54,6 +54,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			try {
 				jwtTokenProvider.validateToken(token);
 
+				if (!jwtTokenProvider.isAccessToken(token)) {
+					log.debug("Token is not an access token");
+					filterChain.doFilter(request, response);
+					return;
+				}
+
 				if (accessTokenBlacklistRepository.isBlacklisted(token)) {
 					log.debug("Token is blacklisted");
 					filterChain.doFilter(request, response);

--- a/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,76 @@
+package com.sopt.cherrish.domain.auth.infrastructure.jwt;
+
+import java.io.IOException;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.sopt.cherrish.domain.auth.exception.AuthErrorCode;
+import com.sopt.cherrish.domain.auth.exception.AuthException;
+import com.sopt.cherrish.domain.user.domain.model.User;
+import com.sopt.cherrish.domain.user.domain.repository.UserRepository;
+import com.sopt.cherrish.global.security.UserPrincipal;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private static final String AUTHORIZATION_HEADER = "Authorization";
+	private static final String BEARER_PREFIX = "Bearer ";
+
+	private final JwtTokenProvider jwtTokenProvider;
+	private final UserRepository userRepository;
+
+	@Override
+	protected void doFilterInternal(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		FilterChain filterChain
+	) throws ServletException, IOException {
+		String token = resolveToken(request);
+
+		if (token != null) {
+			try {
+				if (jwtTokenProvider.validateToken(token)) {
+					Long userId = jwtTokenProvider.getUserId(token);
+					User user = userRepository.findById(userId)
+						.orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+
+					UserPrincipal userPrincipal = UserPrincipal.from(user);
+					UsernamePasswordAuthenticationToken authentication =
+						new UsernamePasswordAuthenticationToken(
+							userPrincipal,
+							null,
+							userPrincipal.getAuthorities()
+						);
+					authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+					SecurityContextHolder.getContext().setAuthentication(authentication);
+				}
+			} catch (AuthException e) {
+				log.debug("JWT authentication failed: {}", e.getMessage());
+			}
+		}
+
+		filterChain.doFilter(request, response);
+	}
+
+	private String resolveToken(HttpServletRequest request) {
+		String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+			return bearerToken.substring(BEARER_PREFIX.length());
+		}
+		return null;
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtAuthenticationFilter.java
@@ -43,21 +43,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 		if (token != null) {
 			try {
-				if (jwtTokenProvider.validateToken(token)) {
-					Long userId = jwtTokenProvider.getUserId(token);
-					User user = userRepository.findById(userId)
-						.orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+				jwtTokenProvider.validateToken(token);
 
-					UserPrincipal userPrincipal = UserPrincipal.from(user);
-					UsernamePasswordAuthenticationToken authentication =
-						new UsernamePasswordAuthenticationToken(
-							userPrincipal,
-							null,
-							userPrincipal.getAuthorities()
-						);
-					authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-					SecurityContextHolder.getContext().setAuthentication(authentication);
-				}
+				Long userId = jwtTokenProvider.getUserId(token);
+				User user = userRepository.findById(userId)
+					.orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+
+				UserPrincipal userPrincipal = UserPrincipal.from(user);
+				UsernamePasswordAuthenticationToken authentication =
+					new UsernamePasswordAuthenticationToken(
+						userPrincipal,
+						null,
+						userPrincipal.getAuthorities()
+					);
+				authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+				SecurityContextHolder.getContext().setAuthentication(authentication);
 			} catch (AuthException e) {
 				log.debug("JWT authentication failed: {}", e.getMessage());
 			}

--- a/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtAuthenticationFilter.java
@@ -22,6 +22,16 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * JWT 기반 인증을 처리하는 필터.
+ *
+ * <p>모든 요청에서 Authorization 헤더의 Bearer 토큰을 추출하여 검증합니다.
+ * 토큰이 유효하면 SecurityContext에 인증 정보를 설정합니다.</p>
+ *
+ * <p>토큰이 없거나 유효하지 않은 경우 인증을 설정하지 않고 다음 필터로 진행합니다.
+ * 보호된 리소스 접근시 {@link com.sopt.cherrish.global.security.JwtAuthenticationEntryPoint}에서
+ * 401 응답을 반환합니다.</p>
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtAuthenticationFilter.java
@@ -5,8 +5,6 @@ import java.io.IOException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
-import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.sopt.cherrish.domain.auth.domain.repository.AccessTokenBlacklistRepository;
@@ -38,7 +36,6 @@ import lombok.extern.slf4j.Slf4j;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 	private static final String AUTHORIZATION_HEADER = "Authorization";
-	private static final String BEARER_PREFIX = "Bearer ";
 
 	private final JwtTokenProvider jwtTokenProvider;
 	private final UserRepository userRepository;
@@ -50,7 +47,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		HttpServletResponse response,
 		FilterChain filterChain
 	) throws ServletException, IOException {
-		String token = resolveToken(request);
+		String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
+		String token = jwtTokenProvider.extractToken(authorizationHeader);
 
 		if (token != null) {
 			try {
@@ -81,13 +79,5 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		}
 
 		filterChain.doFilter(request, response);
-	}
-
-	private String resolveToken(HttpServletRequest request) {
-		String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
-		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
-			return bearerToken.substring(BEARER_PREFIX.length());
-		}
-		return null;
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtProperties.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtProperties.java
@@ -2,17 +2,26 @@ package com.sopt.cherrish.domain.auth.infrastructure.jwt;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 @Component
+@Validated
 @ConfigurationProperties(prefix = "jwt")
 public class JwtProperties {
 
+	@NotBlank
 	private String secretKey;
+
+	@Positive
 	private long accessTokenExpiration;
+
+	@Positive
 	private long refreshTokenExpiration;
 }

--- a/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtProperties.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtProperties.java
@@ -1,0 +1,18 @@
+package com.sopt.cherrish.domain.auth.infrastructure.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+
+	private String secretKey;
+	private long accessTokenExpiration;
+	private long refreshTokenExpiration;
+}

--- a/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtTokenProvider.java
@@ -102,17 +102,8 @@ public class JwtTokenProvider {
 		} catch (ExpiredJwtException e) {
 			log.debug("Expired JWT token: {}", e.getMessage());
 			throw new AuthException(AuthErrorCode.TOKEN_EXPIRED);
-		} catch (UnsupportedJwtException e) {
-			log.debug("Unsupported JWT token: {}", e.getMessage());
-			throw new AuthException(AuthErrorCode.INVALID_TOKEN);
-		} catch (MalformedJwtException e) {
-			log.debug("Malformed JWT token: {}", e.getMessage());
-			throw new AuthException(AuthErrorCode.INVALID_TOKEN);
-		} catch (SecurityException e) {
-			log.debug("Invalid JWT signature: {}", e.getMessage());
-			throw new AuthException(AuthErrorCode.INVALID_TOKEN);
-		} catch (IllegalArgumentException e) {
-			log.debug("JWT claims string is empty: {}", e.getMessage());
+		} catch (UnsupportedJwtException | MalformedJwtException | SecurityException | IllegalArgumentException e) {
+			log.debug("Invalid JWT token: {}", e.getMessage());
 			throw new AuthException(AuthErrorCode.INVALID_TOKEN);
 		}
 	}

--- a/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtTokenProvider.java
@@ -109,6 +109,17 @@ public class JwtTokenProvider {
 	}
 
 	/**
+	 * 토큰이 Access Token인지 확인합니다.
+	 *
+	 * @param token JWT 토큰
+	 * @return Access Token이면 true, Refresh Token이면 false
+	 */
+	public boolean isAccessToken(String token) {
+		Claims claims = parseClaims(token);
+		return ACCESS_TOKEN_TYPE.equals(claims.get(TOKEN_TYPE_CLAIM, String.class));
+	}
+
+	/**
 	 * 토큰이 Refresh Token인지 확인합니다.
 	 *
 	 * @param token JWT 토큰

--- a/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtTokenProvider.java
@@ -142,6 +142,36 @@ public class JwtTokenProvider {
 		return jwtProperties.getRefreshTokenExpiration();
 	}
 
+	/**
+	 * 토큰의 남은 만료 시간(밀리초)을 반환합니다.
+	 *
+	 * @param token JWT 토큰
+	 * @return 남은 만료 시간 (밀리초), 이미 만료된 경우 0
+	 */
+	public long getRemainingExpiration(String token) {
+		try {
+			Claims claims = parseClaims(token);
+			Date expiration = claims.getExpiration();
+			long remaining = expiration.getTime() - System.currentTimeMillis();
+			return Math.max(0, remaining);
+		} catch (Exception e) {
+			return 0;
+		}
+	}
+
+	/**
+	 * Authorization 헤더에서 Bearer 토큰을 추출합니다.
+	 *
+	 * @param authorizationHeader Authorization 헤더 값
+	 * @return 추출된 토큰, 유효하지 않은 형식이면 null
+	 */
+	public String extractToken(String authorizationHeader) {
+		if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+			return authorizationHeader.substring(7);
+		}
+		return null;
+	}
+
 	private Claims parseClaims(String token) {
 		return Jwts.parser()
 			.verifyWith(secretKey)

--- a/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtTokenProvider.java
@@ -1,0 +1,110 @@
+package com.sopt.cherrish.domain.auth.infrastructure.jwt;
+
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.stereotype.Component;
+
+import com.sopt.cherrish.domain.auth.exception.AuthErrorCode;
+import com.sopt.cherrish.domain.auth.exception.AuthException;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+	private static final String TOKEN_TYPE_CLAIM = "type";
+	private static final String ACCESS_TOKEN_TYPE = "access";
+	private static final String REFRESH_TOKEN_TYPE = "refresh";
+
+	private final JwtProperties jwtProperties;
+	private SecretKey secretKey;
+
+	@PostConstruct
+	protected void init() {
+		byte[] keyBytes = Decoders.BASE64.decode(jwtProperties.getSecretKey());
+		this.secretKey = Keys.hmacShaKeyFor(keyBytes);
+	}
+
+	public String createAccessToken(Long userId) {
+		Date now = new Date();
+		Date expiration = new Date(now.getTime() + jwtProperties.getAccessTokenExpiration());
+
+		return Jwts.builder()
+			.subject(String.valueOf(userId))
+			.claim(TOKEN_TYPE_CLAIM, ACCESS_TOKEN_TYPE)
+			.issuedAt(now)
+			.expiration(expiration)
+			.signWith(secretKey)
+			.compact();
+	}
+
+	public String createRefreshToken(Long userId) {
+		Date now = new Date();
+		Date expiration = new Date(now.getTime() + jwtProperties.getRefreshTokenExpiration());
+
+		return Jwts.builder()
+			.subject(String.valueOf(userId))
+			.claim(TOKEN_TYPE_CLAIM, REFRESH_TOKEN_TYPE)
+			.issuedAt(now)
+			.expiration(expiration)
+			.signWith(secretKey)
+			.compact();
+	}
+
+	public Long getUserId(String token) {
+		Claims claims = parseClaims(token);
+		return Long.parseLong(claims.getSubject());
+	}
+
+	public boolean validateToken(String token) {
+		try {
+			parseClaims(token);
+			return true;
+		} catch (ExpiredJwtException e) {
+			log.debug("Expired JWT token: {}", e.getMessage());
+			throw new AuthException(AuthErrorCode.TOKEN_EXPIRED);
+		} catch (UnsupportedJwtException e) {
+			log.debug("Unsupported JWT token: {}", e.getMessage());
+			throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+		} catch (MalformedJwtException e) {
+			log.debug("Malformed JWT token: {}", e.getMessage());
+			throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+		} catch (SecurityException e) {
+			log.debug("Invalid JWT signature: {}", e.getMessage());
+			throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+		} catch (IllegalArgumentException e) {
+			log.debug("JWT claims string is empty: {}", e.getMessage());
+			throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+		}
+	}
+
+	public boolean isRefreshToken(String token) {
+		Claims claims = parseClaims(token);
+		return REFRESH_TOKEN_TYPE.equals(claims.get(TOKEN_TYPE_CLAIM, String.class));
+	}
+
+	public long getRefreshTokenExpiration() {
+		return jwtProperties.getRefreshTokenExpiration();
+	}
+
+	private Claims parseClaims(String token) {
+		return Jwts.parser()
+			.verifyWith(secretKey)
+			.build()
+			.parseSignedClaims(token)
+			.getPayload();
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtTokenProvider.java
@@ -51,16 +51,7 @@ public class JwtTokenProvider {
 	 * @return 생성된 Access Token 문자열
 	 */
 	public String createAccessToken(Long userId) {
-		Date now = new Date();
-		Date expiration = new Date(now.getTime() + jwtProperties.getAccessTokenExpiration());
-
-		return Jwts.builder()
-			.subject(String.valueOf(userId))
-			.claim(TOKEN_TYPE_CLAIM, ACCESS_TOKEN_TYPE)
-			.issuedAt(now)
-			.expiration(expiration)
-			.signWith(secretKey)
-			.compact();
+		return createToken(userId, ACCESS_TOKEN_TYPE, jwtProperties.getAccessTokenExpiration());
 	}
 
 	/**
@@ -70,12 +61,16 @@ public class JwtTokenProvider {
 	 * @return 생성된 Refresh Token 문자열
 	 */
 	public String createRefreshToken(Long userId) {
+		return createToken(userId, REFRESH_TOKEN_TYPE, jwtProperties.getRefreshTokenExpiration());
+	}
+
+	private String createToken(Long userId, String tokenType, long expirationTime) {
 		Date now = new Date();
-		Date expiration = new Date(now.getTime() + jwtProperties.getRefreshTokenExpiration());
+		Date expiration = new Date(now.getTime() + expirationTime);
 
 		return Jwts.builder()
 			.subject(String.valueOf(userId))
-			.claim(TOKEN_TYPE_CLAIM, REFRESH_TOKEN_TYPE)
+			.claim(TOKEN_TYPE_CLAIM, tokenType)
 			.issuedAt(now)
 			.expiration(expiration)
 			.signWith(secretKey)

--- a/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtTokenProvider.java
@@ -164,7 +164,7 @@ public class JwtTokenProvider {
 	 * 토큰의 남은 만료 시간(밀리초)을 반환합니다.
 	 *
 	 * @param token JWT 토큰
-	 * @return 남은 만료 시간 (밀리초), 이미 만료된 경우 0
+	 * @return 남은 만료 시간 (밀리초), 이미 만료되었거나 유효하지 않은 경우 0
 	 */
 	public long getRemainingExpiration(String token) {
 		try {
@@ -172,7 +172,12 @@ public class JwtTokenProvider {
 			Date expiration = claims.getExpiration();
 			long remaining = expiration.getTime() - System.currentTimeMillis();
 			return Math.max(0, remaining);
+		} catch (ExpiredJwtException | UnsupportedJwtException | MalformedJwtException
+				 | SecurityException | IllegalArgumentException e) {
+			log.debug("Expected JWT exception in getRemainingExpiration: {}", e.getMessage());
+			return 0;
 		} catch (Exception e) {
+			log.warn("Unexpected exception in getRemainingExpiration: {}", e.getMessage(), e);
 			return 0;
 		}
 	}

--- a/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtTokenProvider.java
@@ -82,10 +82,16 @@ public class JwtTokenProvider {
 	 *
 	 * @param token JWT 토큰
 	 * @return 사용자 ID
+	 * @throws AuthException subject가 유효한 사용자 ID가 아닌 경우
 	 */
 	public Long getUserId(String token) {
-		Claims claims = parseClaims(token);
-		return Long.parseLong(claims.getSubject());
+		try {
+			Claims claims = parseClaims(token);
+			return Long.parseLong(claims.getSubject());
+		} catch (NumberFormatException | NullPointerException e) {
+			log.debug("Invalid user ID in token: {}", e.getMessage());
+			throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+		}
 	}
 
 	/**

--- a/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtTokenProvider.java
@@ -69,10 +69,9 @@ public class JwtTokenProvider {
 		return Long.parseLong(claims.getSubject());
 	}
 
-	public boolean validateToken(String token) {
+	public void validateToken(String token) {
 		try {
 			parseClaims(token);
-			return true;
 		} catch (ExpiredJwtException e) {
 			log.debug("Expired JWT token: {}", e.getMessage());
 			throw new AuthException(AuthErrorCode.TOKEN_EXPIRED);

--- a/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/jwt/JwtTokenProvider.java
@@ -20,6 +20,12 @@ import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * JWT 토큰 생성 및 검증을 담당하는 컴포넌트.
+ *
+ * <p>Access Token과 Refresh Token을 생성하고, 토큰의 유효성을 검증합니다.
+ * 토큰에는 사용자 ID와 토큰 타입(access/refresh)이 포함됩니다.</p>
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -38,6 +44,12 @@ public class JwtTokenProvider {
 		this.secretKey = Keys.hmacShaKeyFor(keyBytes);
 	}
 
+	/**
+	 * Access Token을 생성합니다.
+	 *
+	 * @param userId 사용자 ID
+	 * @return 생성된 Access Token 문자열
+	 */
 	public String createAccessToken(Long userId) {
 		Date now = new Date();
 		Date expiration = new Date(now.getTime() + jwtProperties.getAccessTokenExpiration());
@@ -51,6 +63,12 @@ public class JwtTokenProvider {
 			.compact();
 	}
 
+	/**
+	 * Refresh Token을 생성합니다.
+	 *
+	 * @param userId 사용자 ID
+	 * @return 생성된 Refresh Token 문자열
+	 */
 	public String createRefreshToken(Long userId) {
 		Date now = new Date();
 		Date expiration = new Date(now.getTime() + jwtProperties.getRefreshTokenExpiration());
@@ -64,11 +82,25 @@ public class JwtTokenProvider {
 			.compact();
 	}
 
+	/**
+	 * 토큰에서 사용자 ID를 추출합니다.
+	 *
+	 * @param token JWT 토큰
+	 * @return 사용자 ID
+	 */
 	public Long getUserId(String token) {
 		Claims claims = parseClaims(token);
 		return Long.parseLong(claims.getSubject());
 	}
 
+	/**
+	 * 토큰의 유효성을 검증합니다.
+	 *
+	 * <p>토큰이 유효하면 정상 반환되고, 유효하지 않으면 예외가 발생합니다.</p>
+	 *
+	 * @param token 검증할 JWT 토큰
+	 * @throws AuthException 토큰이 만료되었거나 유효하지 않은 경우
+	 */
 	public void validateToken(String token) {
 		try {
 			parseClaims(token);
@@ -90,11 +122,22 @@ public class JwtTokenProvider {
 		}
 	}
 
+	/**
+	 * 토큰이 Refresh Token인지 확인합니다.
+	 *
+	 * @param token JWT 토큰
+	 * @return Refresh Token이면 true, Access Token이면 false
+	 */
 	public boolean isRefreshToken(String token) {
 		Claims claims = parseClaims(token);
 		return REFRESH_TOKEN_TYPE.equals(claims.get(TOKEN_TYPE_CLAIM, String.class));
 	}
 
+	/**
+	 * Refresh Token의 만료 시간(밀리초)을 반환합니다.
+	 *
+	 * @return Refresh Token 만료 시간 (밀리초)
+	 */
 	public long getRefreshTokenExpiration() {
 		return jwtProperties.getRefreshTokenExpiration();
 	}

--- a/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/social/AppleAuthClient.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/social/AppleAuthClient.java
@@ -23,6 +23,14 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * Apple Sign In 토큰 검증 클라이언트.
+ *
+ * <p>Apple Identity Token을 검증하고 사용자 정보를 추출합니다.
+ * Apple 공개키는 24시간 동안 캐싱되어 성능을 최적화합니다.</p>
+ *
+ * @see <a href="https://developer.apple.com/documentation/sign_in_with_apple">Apple Sign In Documentation</a>
+ */
 @Slf4j
 @Component
 public class AppleAuthClient implements SocialAuthClient {
@@ -45,6 +53,15 @@ public class AppleAuthClient implements SocialAuthClient {
 		this.objectMapper = objectMapper;
 	}
 
+	/**
+	 * Apple Identity Token을 검증하고 사용자 정보를 추출합니다.
+	 *
+	 * <p>토큰의 서명을 Apple 공개키로 검증하고, issuer와 audience를 확인합니다.</p>
+	 *
+	 * @param identityToken Apple에서 발급한 Identity Token (JWT)
+	 * @return 소셜 사용자 정보 (socialId, email)
+	 * @throws AuthException 토큰이 유효하지 않거나 검증에 실패한 경우
+	 */
 	@Override
 	public SocialUserInfo getUserInfo(String identityToken) {
 		try {

--- a/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/social/AppleAuthClient.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/social/AppleAuthClient.java
@@ -1,0 +1,123 @@
+package com.sopt.cherrish.domain.auth.infrastructure.social;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sopt.cherrish.domain.auth.exception.AuthErrorCode;
+import com.sopt.cherrish.domain.auth.exception.AuthException;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AppleAuthClient implements SocialAuthClient {
+
+	private static final String APPLE_PUBLIC_KEY_URL = "https://appleid.apple.com/auth/keys";
+	private static final String APPLE_ISSUER = "https://appleid.apple.com";
+
+	private final RestTemplate restTemplate;
+	private final ObjectMapper objectMapper;
+
+	@Value("${social.apple.client-id}")
+	private String clientId;
+
+	@Override
+	public SocialUserInfo getUserInfo(String identityToken) {
+		try {
+			ApplePublicKeys applePublicKeys = restTemplate.getForObject(
+				APPLE_PUBLIC_KEY_URL,
+				ApplePublicKeys.class
+			);
+
+			if (applePublicKeys == null || applePublicKeys.keys() == null) {
+				throw new AuthException(AuthErrorCode.SOCIAL_AUTH_FAILED);
+			}
+
+			String[] tokenParts = identityToken.split("\\.");
+			if (tokenParts.length != 3) {
+				throw new AuthException(AuthErrorCode.INVALID_SOCIAL_TOKEN);
+			}
+
+			String headerJson = new String(Base64.getUrlDecoder().decode(tokenParts[0]));
+			JsonNode headerNode = objectMapper.readTree(headerJson);
+			String kid = headerNode.get("kid").asText();
+			String alg = headerNode.get("alg").asText();
+
+			ApplePublicKey matchedKey = applePublicKeys.keys().stream()
+				.filter(key -> key.kid().equals(kid) && key.alg().equals(alg))
+				.findFirst()
+				.orElseThrow(() -> new AuthException(AuthErrorCode.INVALID_SOCIAL_TOKEN));
+
+			PublicKey publicKey = generatePublicKey(matchedKey);
+
+			Claims claims = Jwts.parser()
+				.verifyWith(publicKey)
+				.requireIssuer(APPLE_ISSUER)
+				.requireAudience(clientId)
+				.build()
+				.parseSignedClaims(identityToken)
+				.getPayload();
+
+			return new SocialUserInfo(
+				claims.getSubject(),
+				claims.get("email", String.class),
+				null
+			);
+		} catch (ExpiredJwtException e) {
+			log.error("Apple identity token expired");
+			throw new AuthException(AuthErrorCode.TOKEN_EXPIRED);
+		} catch (AuthException e) {
+			throw e;
+		} catch (Exception e) {
+			log.error("Apple auth error: {}", e.getMessage(), e);
+			throw new AuthException(AuthErrorCode.SOCIAL_AUTH_FAILED);
+		}
+	}
+
+	private PublicKey generatePublicKey(ApplePublicKey appleKey) {
+		try {
+			byte[] nBytes = Base64.getUrlDecoder().decode(appleKey.n());
+			byte[] eBytes = Base64.getUrlDecoder().decode(appleKey.e());
+
+			BigInteger modulus = new BigInteger(1, nBytes);
+			BigInteger exponent = new BigInteger(1, eBytes);
+
+			RSAPublicKeySpec spec = new RSAPublicKeySpec(modulus, exponent);
+			KeyFactory factory = KeyFactory.getInstance("RSA");
+			return factory.generatePublic(spec);
+		} catch (Exception e) {
+			log.error("Failed to generate Apple public key: {}", e.getMessage(), e);
+			throw new AuthException(AuthErrorCode.SOCIAL_AUTH_FAILED);
+		}
+	}
+
+	private record ApplePublicKeys(
+		List<ApplePublicKey> keys
+	) {
+	}
+
+	private record ApplePublicKey(
+		String kty,
+		String kid,
+		String use,
+		String alg,
+		String n,
+		String e
+	) {
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/social/KakaoAuthClient.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/social/KakaoAuthClient.java
@@ -16,6 +16,13 @@ import com.sopt.cherrish.domain.auth.exception.AuthException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * 카카오 로그인 토큰 검증 클라이언트.
+ *
+ * <p>카카오 Access Token을 사용하여 카카오 API에서 사용자 정보를 조회합니다.</p>
+ *
+ * @see <a href="https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api">카카오 로그인 API 문서</a>
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -25,6 +32,15 @@ public class KakaoAuthClient implements SocialAuthClient {
 
 	private final RestTemplate restTemplate;
 
+	/**
+	 * 카카오 Access Token으로 사용자 정보를 조회합니다.
+	 *
+	 * <p>카카오 사용자 정보 API(/v2/user/me)를 호출하여 사용자 정보를 가져옵니다.</p>
+	 *
+	 * @param accessToken 카카오에서 발급한 Access Token
+	 * @return 소셜 사용자 정보 (socialId, email, nickname)
+	 * @throws AuthException 토큰이 유효하지 않거나 API 호출에 실패한 경우
+	 */
 	@Override
 	public SocialUserInfo getUserInfo(String accessToken) {
 		try {

--- a/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/social/KakaoAuthClient.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/social/KakaoAuthClient.java
@@ -1,0 +1,82 @@
+package com.sopt.cherrish.domain.auth.infrastructure.social;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sopt.cherrish.domain.auth.exception.AuthErrorCode;
+import com.sopt.cherrish.domain.auth.exception.AuthException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KakaoAuthClient implements SocialAuthClient {
+
+	private static final String KAKAO_USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+
+	private final RestTemplate restTemplate;
+
+	@Override
+	public SocialUserInfo getUserInfo(String accessToken) {
+		try {
+			HttpHeaders headers = new HttpHeaders();
+			headers.setBearerAuth(accessToken);
+			headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+			HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+			ResponseEntity<KakaoUserResponse> response = restTemplate.exchange(
+				KAKAO_USER_INFO_URL,
+				HttpMethod.GET,
+				entity,
+				KakaoUserResponse.class
+			);
+
+			KakaoUserResponse body = response.getBody();
+			if (body == null) {
+				throw new AuthException(AuthErrorCode.SOCIAL_AUTH_FAILED);
+			}
+
+			return new SocialUserInfo(
+				String.valueOf(body.id()),
+				body.kakaoAccount() != null ? body.kakaoAccount().email() : null,
+				body.properties() != null ? body.properties().nickname() : null
+			);
+		} catch (HttpClientErrorException e) {
+			log.error("Kakao token validation failed: status={}, body={}",
+				e.getStatusCode(), e.getResponseBodyAsString());
+			throw new AuthException(AuthErrorCode.INVALID_SOCIAL_TOKEN);
+		} catch (AuthException e) {
+			throw e;
+		} catch (Exception e) {
+			log.error("Kakao auth error: {}", e.getMessage(), e);
+			throw new AuthException(AuthErrorCode.SOCIAL_AUTH_FAILED);
+		}
+	}
+
+	private record KakaoUserResponse(
+		Long id,
+		@JsonProperty("kakao_account") KakaoAccount kakaoAccount,
+		KakaoProperties properties
+	) {
+	}
+
+	private record KakaoAccount(
+		String email
+	) {
+	}
+
+	private record KakaoProperties(
+		String nickname
+	) {
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/social/SocialAuthClient.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/social/SocialAuthClient.java
@@ -1,0 +1,6 @@
+package com.sopt.cherrish.domain.auth.infrastructure.social;
+
+public interface SocialAuthClient {
+
+	SocialUserInfo getUserInfo(String token);
+}

--- a/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/social/SocialAuthClient.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/social/SocialAuthClient.java
@@ -1,6 +1,18 @@
 package com.sopt.cherrish.domain.auth.infrastructure.social;
 
+/**
+ * 소셜 로그인 인증 클라이언트 인터페이스.
+ *
+ * <p>각 소셜 플랫폼(카카오, 애플 등)별로 구현체를 제공합니다.</p>
+ */
 public interface SocialAuthClient {
 
+	/**
+	 * 소셜 토큰을 검증하고 사용자 정보를 조회합니다.
+	 *
+	 * @param token 소셜 플랫폼에서 발급한 토큰
+	 * @return 소셜 사용자 정보
+	 * @throws com.sopt.cherrish.domain.auth.exception.AuthException 토큰이 유효하지 않은 경우
+	 */
 	SocialUserInfo getUserInfo(String token);
 }

--- a/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/social/SocialUserInfo.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/social/SocialUserInfo.java
@@ -1,5 +1,12 @@
 package com.sopt.cherrish.domain.auth.infrastructure.social;
 
+/**
+ * 소셜 플랫폼에서 조회한 사용자 정보.
+ *
+ * @param socialId 소셜 플랫폼의 고유 사용자 ID
+ * @param email 사용자 이메일 (없을 수 있음)
+ * @param nickname 사용자 닉네임 (없을 수 있음)
+ */
 public record SocialUserInfo(
 	String socialId,
 	String email,

--- a/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/social/SocialUserInfo.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/infrastructure/social/SocialUserInfo.java
@@ -1,0 +1,8 @@
+package com.sopt.cherrish.domain.auth.infrastructure.social;
+
+public record SocialUserInfo(
+	String socialId,
+	String email,
+	String nickname
+) {
+}

--- a/src/main/java/com/sopt/cherrish/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/presentation/AuthController.java
@@ -1,0 +1,72 @@
+package com.sopt.cherrish.domain.auth.presentation;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sopt.cherrish.domain.auth.application.service.AuthService;
+import com.sopt.cherrish.domain.auth.exception.AuthErrorCode;
+import com.sopt.cherrish.domain.auth.presentation.dto.request.SocialLoginRequestDto;
+import com.sopt.cherrish.domain.auth.presentation.dto.request.TokenRefreshRequestDto;
+import com.sopt.cherrish.domain.auth.presentation.dto.response.LoginResponseDto;
+import com.sopt.cherrish.domain.auth.presentation.dto.response.TokenResponseDto;
+import com.sopt.cherrish.domain.auth.response.success.AuthSuccessCode;
+import com.sopt.cherrish.global.annotation.ApiExceptions;
+import com.sopt.cherrish.global.response.CommonApiResponse;
+import com.sopt.cherrish.global.response.error.ErrorCode;
+import com.sopt.cherrish.global.security.CurrentUser;
+import com.sopt.cherrish.global.security.UserPrincipal;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+@Tag(name = "Auth", description = "인증 관련 API")
+public class AuthController {
+
+	private final AuthService authService;
+
+	@Operation(
+		summary = "소셜 로그인",
+		description = "카카오 또는 애플 소셜 토큰으로 로그인합니다. 신규 사용자는 isNewUser: true를 반환합니다."
+	)
+	@ApiExceptions({AuthErrorCode.class, ErrorCode.class})
+	@PostMapping("/login")
+	public CommonApiResponse<LoginResponseDto> login(
+		@Valid @RequestBody SocialLoginRequestDto request
+	) {
+		LoginResponseDto response = authService.login(request);
+		return CommonApiResponse.success(AuthSuccessCode.LOGIN_SUCCESS, response);
+	}
+
+	@Operation(
+		summary = "토큰 재발급",
+		description = "Refresh Token으로 새로운 Access Token과 Refresh Token을 발급받습니다."
+	)
+	@ApiExceptions({AuthErrorCode.class, ErrorCode.class})
+	@PostMapping("/refresh")
+	public CommonApiResponse<TokenResponseDto> refresh(
+		@Valid @RequestBody TokenRefreshRequestDto request
+	) {
+		TokenResponseDto response = authService.refresh(request);
+		return CommonApiResponse.success(AuthSuccessCode.TOKEN_REFRESHED, response);
+	}
+
+	@Operation(
+		summary = "로그아웃",
+		description = "현재 사용자의 Refresh Token을 무효화합니다."
+	)
+	@ApiExceptions({AuthErrorCode.class, ErrorCode.class})
+	@PostMapping("/logout")
+	public CommonApiResponse<Void> logout(
+		@CurrentUser UserPrincipal userPrincipal
+	) {
+		authService.logout(userPrincipal.getUserId());
+		return CommonApiResponse.success(AuthSuccessCode.LOGOUT_SUCCESS);
+	}
+}

--- a/src/main/java/com/sopt/cherrish/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/presentation/AuthController.java
@@ -21,6 +21,7 @@ import com.sopt.cherrish.global.security.UserPrincipal;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +38,7 @@ public class AuthController {
 		summary = "소셜 로그인",
 		description = "카카오 또는 애플 소셜 토큰으로 로그인합니다. 신규 사용자는 isNewUser: true를 반환합니다."
 	)
+	@SecurityRequirements
 	@ApiExceptions({AuthErrorCode.class, ErrorCode.class})
 	@PostMapping("/login")
 	public CommonApiResponse<LoginResponseDto> login(
@@ -50,6 +52,7 @@ public class AuthController {
 		summary = "토큰 재발급",
 		description = "Refresh Token으로 새로운 Access Token과 Refresh Token을 발급받습니다."
 	)
+	@SecurityRequirements
 	@ApiExceptions({AuthErrorCode.class, ErrorCode.class})
 	@PostMapping("/refresh")
 	public CommonApiResponse<TokenResponseDto> refresh(

--- a/src/main/java/com/sopt/cherrish/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/presentation/AuthController.java
@@ -2,6 +2,7 @@ package com.sopt.cherrish.domain.auth.presentation;
 
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,6 +20,7 @@ import com.sopt.cherrish.global.security.CurrentUser;
 import com.sopt.cherrish.global.security.UserPrincipal;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -59,14 +61,15 @@ public class AuthController {
 
 	@Operation(
 		summary = "로그아웃",
-		description = "현재 사용자의 Refresh Token을 무효화합니다."
+		description = "현재 사용자의 Refresh Token을 무효화하고 Access Token을 블랙리스트에 추가합니다."
 	)
 	@ApiExceptions({AuthErrorCode.class, ErrorCode.class})
 	@PostMapping("/logout")
 	public CommonApiResponse<Void> logout(
-		@CurrentUser UserPrincipal userPrincipal
+		@CurrentUser UserPrincipal userPrincipal,
+		@Parameter(hidden = true) @RequestHeader("Authorization") String authorizationHeader
 	) {
-		authService.logout(userPrincipal.getUserId());
+		authService.logout(userPrincipal.getUserId(), authorizationHeader);
 		return CommonApiResponse.success(AuthSuccessCode.LOGOUT_SUCCESS);
 	}
 }

--- a/src/main/java/com/sopt/cherrish/domain/auth/presentation/dto/request/SocialLoginRequestDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/presentation/dto/request/SocialLoginRequestDto.java
@@ -1,0 +1,22 @@
+package com.sopt.cherrish.domain.auth.presentation.dto.request;
+
+import com.sopt.cherrish.domain.auth.domain.model.SocialProvider;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "소셜 로그인 요청")
+public record SocialLoginRequestDto(
+
+	@Schema(description = "소셜 로그인 제공자", example = "KAKAO", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotNull(message = "소셜 로그인 제공자는 필수입니다")
+	SocialProvider provider,
+
+	@Schema(description = "소셜 토큰 (카카오: Access Token, 애플: Identity Token)",
+		example = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
+		requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotBlank(message = "소셜 토큰은 필수입니다")
+	String token
+) {
+}

--- a/src/main/java/com/sopt/cherrish/domain/auth/presentation/dto/request/TokenRefreshRequestDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/presentation/dto/request/TokenRefreshRequestDto.java
@@ -1,0 +1,15 @@
+package com.sopt.cherrish.domain.auth.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "토큰 재발급 요청")
+public record TokenRefreshRequestDto(
+
+	@Schema(description = "Refresh Token",
+		example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+		requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotBlank(message = "Refresh Token은 필수입니다")
+	String refreshToken
+) {
+}

--- a/src/main/java/com/sopt/cherrish/domain/auth/presentation/dto/response/LoginResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/presentation/dto/response/LoginResponseDto.java
@@ -1,0 +1,20 @@
+package com.sopt.cherrish.domain.auth.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "로그인 응답")
+public record LoginResponseDto(
+
+	@Schema(description = "사용자 ID", example = "1")
+	Long userId,
+
+	@Schema(description = "신규 사용자 여부 (true인 경우 온보딩 필요)", example = "false")
+	boolean isNewUser,
+
+	@Schema(description = "Access Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+	String accessToken,
+
+	@Schema(description = "Refresh Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+	String refreshToken
+) {
+}

--- a/src/main/java/com/sopt/cherrish/domain/auth/presentation/dto/response/TokenResponseDto.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/presentation/dto/response/TokenResponseDto.java
@@ -1,0 +1,14 @@
+package com.sopt.cherrish.domain.auth.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "토큰 재발급 응답")
+public record TokenResponseDto(
+
+	@Schema(description = "Access Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+	String accessToken,
+
+	@Schema(description = "Refresh Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+	String refreshToken
+) {
+}

--- a/src/main/java/com/sopt/cherrish/domain/auth/response/success/AuthSuccessCode.java
+++ b/src/main/java/com/sopt/cherrish/domain/auth/response/success/AuthSuccessCode.java
@@ -1,0 +1,18 @@
+package com.sopt.cherrish.domain.auth.response.success;
+
+import com.sopt.cherrish.global.response.success.SuccessType;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthSuccessCode implements SuccessType {
+
+	LOGIN_SUCCESS("A200", "로그인 성공"),
+	TOKEN_REFRESHED("A201", "토큰 재발급 성공"),
+	LOGOUT_SUCCESS("A202", "로그아웃 성공");
+
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/sopt/cherrish/domain/user/domain/model/User.java
+++ b/src/main/java/com/sopt/cherrish/domain/user/domain/model/User.java
@@ -11,13 +11,17 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "users")
+@Table(
+	name = "users",
+	uniqueConstraints = @UniqueConstraint(columnNames = {"social_provider", "social_id"})
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseTimeEntity {
@@ -36,7 +40,7 @@ public class User extends BaseTimeEntity {
 	@Column(nullable = false, length = 10)
 	private SocialProvider socialProvider;
 
-	@Column(nullable = false, unique = true)
+	@Column(nullable = false)
 	private String socialId;
 
 	private String email;

--- a/src/main/java/com/sopt/cherrish/domain/user/domain/model/User.java
+++ b/src/main/java/com/sopt/cherrish/domain/user/domain/model/User.java
@@ -39,7 +39,6 @@ public class User extends BaseTimeEntity {
 	@Column(nullable = false, unique = true)
 	private String socialId;
 
-	@Column(unique = true)
 	private String email;
 
 	@Builder

--- a/src/main/java/com/sopt/cherrish/domain/user/domain/model/User.java
+++ b/src/main/java/com/sopt/cherrish/domain/user/domain/model/User.java
@@ -1,9 +1,12 @@
 package com.sopt.cherrish.domain.user.domain.model;
 
+import com.sopt.cherrish.domain.auth.domain.model.SocialProvider;
 import com.sopt.cherrish.global.entity.BaseTimeEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -29,10 +32,23 @@ public class User extends BaseTimeEntity {
 	@Column(nullable = false)
 	private int age;
 
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 10)
+	private SocialProvider socialProvider;
+
+	@Column(nullable = false, unique = true)
+	private String socialId;
+
+	@Column(unique = true)
+	private String email;
+
 	@Builder
-	private User(String name, int age) {
+	private User(String name, int age, SocialProvider socialProvider, String socialId, String email) {
 		this.name = name;
 		this.age = age;
+		this.socialProvider = socialProvider;
+		this.socialId = socialId;
+		this.email = email;
 	}
 
 	public void update(String name, Integer age) {

--- a/src/main/java/com/sopt/cherrish/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/sopt/cherrish/domain/user/domain/repository/UserRepository.java
@@ -1,8 +1,15 @@
 package com.sopt.cherrish.domain.user.domain.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.sopt.cherrish.domain.auth.domain.model.SocialProvider;
 import com.sopt.cherrish.domain.user.domain.model.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+
+	Optional<User> findBySocialProviderAndSocialId(SocialProvider socialProvider, String socialId);
+
+	boolean existsBySocialProviderAndSocialId(SocialProvider socialProvider, String socialId);
 }

--- a/src/main/java/com/sopt/cherrish/global/config/JpaAuditConfig.java
+++ b/src/main/java/com/sopt/cherrish/global/config/JpaAuditConfig.java
@@ -2,8 +2,10 @@ package com.sopt.cherrish.global.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
-@EnableJpaAuditing
 @Configuration
+@EnableJpaAuditing
+@EnableJpaRepositories(basePackages = "com.sopt.cherrish.domain")
 public class JpaAuditConfig {
 }

--- a/src/main/java/com/sopt/cherrish/global/config/RedisConfig.java
+++ b/src/main/java/com/sopt/cherrish/global/config/RedisConfig.java
@@ -1,0 +1,22 @@
+package com.sopt.cherrish.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+	@Bean
+	public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, String> template = new RedisTemplate<>();
+		template.setConnectionFactory(connectionFactory);
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setValueSerializer(new StringRedisSerializer());
+		template.setHashKeySerializer(new StringRedisSerializer());
+		template.setHashValueSerializer(new StringRedisSerializer());
+		return template;
+	}
+}

--- a/src/main/java/com/sopt/cherrish/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/sopt/cherrish/global/config/RestTemplateConfig.java
@@ -1,0 +1,20 @@
+package com.sopt.cherrish.global.config;
+
+import java.time.Duration;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+	@Bean
+	public RestTemplate restTemplate(RestTemplateBuilder builder) {
+		return builder
+			.connectTimeout(Duration.ofSeconds(5))
+			.readTimeout(Duration.ofSeconds(5))
+			.build();
+	}
+}

--- a/src/main/java/com/sopt/cherrish/global/config/SecurityConfig.java
+++ b/src/main/java/com/sopt/cherrish/global/config/SecurityConfig.java
@@ -1,0 +1,68 @@
+package com.sopt.cherrish.global.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import com.sopt.cherrish.domain.auth.infrastructure.jwt.JwtAuthenticationFilter;
+import com.sopt.cherrish.global.security.JwtAccessDeniedHandler;
+import com.sopt.cherrish.global.security.JwtAuthenticationEntryPoint;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+	private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		return http
+			.csrf(AbstractHttpConfigurer::disable)
+			.sessionManagement(session ->
+				session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.cors(cors -> cors.configurationSource(corsConfigurationSource()))
+			.exceptionHandling(exception -> exception
+				.authenticationEntryPoint(jwtAuthenticationEntryPoint)
+				.accessDeniedHandler(jwtAccessDeniedHandler))
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers(
+					"/api/auth/**",
+					"/swagger-ui/**",
+					"/swagger-ui.html",
+					"/v3/api-docs/**",
+					"/actuator/health"
+				).permitAll()
+				.anyRequest().authenticated())
+			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+			.build();
+	}
+
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+		configuration.setAllowedOriginPatterns(List.of("*"));
+		configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+		configuration.setAllowedHeaders(List.of("*"));
+		configuration.setAllowCredentials(true);
+		configuration.setMaxAge(3600L);
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
+	}
+}

--- a/src/main/java/com/sopt/cherrish/global/config/SecurityConfig.java
+++ b/src/main/java/com/sopt/cherrish/global/config/SecurityConfig.java
@@ -53,7 +53,8 @@ public class SecurityConfig {
 				.accessDeniedHandler(jwtAccessDeniedHandler))
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers(
-					"/api/auth/**",
+					"/api/auth/login",
+					"/api/auth/refresh",
 					"/swagger-ui/**",
 					"/swagger-ui.html",
 					"/v3/api-docs/**",

--- a/src/main/java/com/sopt/cherrish/global/config/SecurityConfig.java
+++ b/src/main/java/com/sopt/cherrish/global/config/SecurityConfig.java
@@ -14,7 +14,10 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import com.sopt.cherrish.domain.auth.domain.repository.AccessTokenBlacklistRepository;
 import com.sopt.cherrish.domain.auth.infrastructure.jwt.JwtAuthenticationFilter;
+import com.sopt.cherrish.domain.auth.infrastructure.jwt.JwtTokenProvider;
+import com.sopt.cherrish.domain.user.domain.repository.UserRepository;
 import com.sopt.cherrish.global.security.JwtAccessDeniedHandler;
 import com.sopt.cherrish.global.security.JwtAuthenticationEntryPoint;
 
@@ -25,7 +28,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final JwtTokenProvider jwtTokenProvider;
+	private final UserRepository userRepository;
+	private final AccessTokenBlacklistRepository accessTokenBlacklistRepository;
 	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 	private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
@@ -55,8 +60,13 @@ public class SecurityConfig {
 					"/actuator/health"
 				).permitAll()
 				.anyRequest().authenticated())
-			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+			.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
 			.build();
+	}
+
+	@Bean
+	public JwtAuthenticationFilter jwtAuthenticationFilter() {
+		return new JwtAuthenticationFilter(jwtTokenProvider, userRepository, accessTokenBlacklistRepository);
 	}
 
 	@Bean

--- a/src/main/java/com/sopt/cherrish/global/config/SecurityConfig.java
+++ b/src/main/java/com/sopt/cherrish/global/config/SecurityConfig.java
@@ -29,6 +29,13 @@ public class SecurityConfig {
 	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 	private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
+	/**
+	 * Security Filter Chain을 구성합니다.
+	 *
+	 * @param http HttpSecurity 설정 객체
+	 * @return 구성된 SecurityFilterChain
+	 * @throws Exception 설정 중 발생할 수 있는 예외
+	 */
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		return http

--- a/src/main/java/com/sopt/cherrish/global/security/CurrentUser.java
+++ b/src/main/java/com/sopt/cherrish/global/security/CurrentUser.java
@@ -1,0 +1,14 @@
+package com.sopt.cherrish.global.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal
+public @interface CurrentUser {
+}

--- a/src/main/java/com/sopt/cherrish/global/security/CurrentUser.java
+++ b/src/main/java/com/sopt/cherrish/global/security/CurrentUser.java
@@ -7,6 +7,19 @@ import java.lang.annotation.Target;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
+/**
+ * 현재 인증된 사용자 정보를 주입받기 위한 커스텀 어노테이션.
+ *
+ * <p>컨트롤러 메서드 파라미터에 사용하여 {@link UserPrincipal}을 주입받습니다.</p>
+ *
+ * <pre>{@code
+ * @GetMapping("/me")
+ * public ResponseEntity<?> getMe(@CurrentUser UserPrincipal userPrincipal) {
+ *     Long userId = userPrincipal.getUserId();
+ *     // ...
+ * }
+ * }</pre>
+ */
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 @AuthenticationPrincipal

--- a/src/main/java/com/sopt/cherrish/global/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/sopt/cherrish/global/security/JwtAccessDeniedHandler.java
@@ -16,6 +16,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * 권한이 없는 요청에 대한 처리를 담당하는 Handler.
+ *
+ * <p>인증은 되었으나 해당 리소스에 대한 권한이 없는 경우 403 Forbidden 응답을 반환합니다.</p>
+ */
 @Component
 @RequiredArgsConstructor
 public class JwtAccessDeniedHandler implements AccessDeniedHandler {

--- a/src/main/java/com/sopt/cherrish/global/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/sopt/cherrish/global/security/JwtAccessDeniedHandler.java
@@ -1,16 +1,12 @@
 package com.sopt.cherrish.global.security;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
-import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sopt.cherrish.domain.auth.exception.AuthErrorCode;
-import com.sopt.cherrish.global.response.CommonApiResponse;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -25,7 +21,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class JwtAccessDeniedHandler implements AccessDeniedHandler {
 
-	private final ObjectMapper objectMapper;
+	private final SecurityErrorResponseWriter errorResponseWriter;
 
 	@Override
 	public void handle(
@@ -33,11 +29,10 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
 		HttpServletResponse response,
 		AccessDeniedException accessDeniedException
 	) throws IOException {
-		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-		response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-		response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-
-		CommonApiResponse<Void> errorResponse = CommonApiResponse.fail(AuthErrorCode.ACCESS_DENIED);
-		response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+		errorResponseWriter.writeErrorResponse(
+			response,
+			HttpServletResponse.SC_FORBIDDEN,
+			AuthErrorCode.ACCESS_DENIED
+		);
 	}
 }

--- a/src/main/java/com/sopt/cherrish/global/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/sopt/cherrish/global/security/JwtAccessDeniedHandler.java
@@ -1,0 +1,38 @@
+package com.sopt.cherrish.global.security;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sopt.cherrish.domain.auth.exception.AuthErrorCode;
+import com.sopt.cherrish.global.response.CommonApiResponse;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void handle(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		AccessDeniedException accessDeniedException
+	) throws IOException {
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+		response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+		CommonApiResponse<Void> errorResponse = CommonApiResponse.fail(AuthErrorCode.ACCESS_DENIED);
+		response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+	}
+}

--- a/src/main/java/com/sopt/cherrish/global/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/sopt/cherrish/global/security/JwtAccessDeniedHandler.java
@@ -29,10 +29,6 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
 		HttpServletResponse response,
 		AccessDeniedException accessDeniedException
 	) throws IOException {
-		errorResponseWriter.writeErrorResponse(
-			response,
-			HttpServletResponse.SC_FORBIDDEN,
-			AuthErrorCode.ACCESS_DENIED
-		);
+		errorResponseWriter.writeErrorResponse(response, AuthErrorCode.ACCESS_DENIED);
 	}
 }

--- a/src/main/java/com/sopt/cherrish/global/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/sopt/cherrish/global/security/JwtAuthenticationEntryPoint.java
@@ -1,16 +1,12 @@
 package com.sopt.cherrish.global.security;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
-import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sopt.cherrish.domain.auth.exception.AuthErrorCode;
-import com.sopt.cherrish.global.response.CommonApiResponse;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -26,7 +22,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
-	private final ObjectMapper objectMapper;
+	private final SecurityErrorResponseWriter errorResponseWriter;
 
 	@Override
 	public void commence(
@@ -34,11 +30,10 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 		HttpServletResponse response,
 		AuthenticationException authException
 	) throws IOException {
-		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-		response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-
-		CommonApiResponse<Void> errorResponse = CommonApiResponse.fail(AuthErrorCode.UNAUTHORIZED);
-		response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+		errorResponseWriter.writeErrorResponse(
+			response,
+			HttpServletResponse.SC_UNAUTHORIZED,
+			AuthErrorCode.UNAUTHORIZED
+		);
 	}
 }

--- a/src/main/java/com/sopt/cherrish/global/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/sopt/cherrish/global/security/JwtAuthenticationEntryPoint.java
@@ -30,10 +30,6 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 		HttpServletResponse response,
 		AuthenticationException authException
 	) throws IOException {
-		errorResponseWriter.writeErrorResponse(
-			response,
-			HttpServletResponse.SC_UNAUTHORIZED,
-			AuthErrorCode.UNAUTHORIZED
-		);
+		errorResponseWriter.writeErrorResponse(response, AuthErrorCode.UNAUTHORIZED);
 	}
 }

--- a/src/main/java/com/sopt/cherrish/global/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/sopt/cherrish/global/security/JwtAuthenticationEntryPoint.java
@@ -16,6 +16,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * 인증되지 않은 요청에 대한 처리를 담당하는 EntryPoint.
+ *
+ * <p>JWT 토큰이 없거나 유효하지 않은 경우 401 Unauthorized 응답을 반환합니다.
+ * Spring Security 필터 체인에서 발생하는 인증 예외를 처리합니다.</p>
+ */
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {

--- a/src/main/java/com/sopt/cherrish/global/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/sopt/cherrish/global/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,38 @@
+package com.sopt.cherrish.global.security;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sopt.cherrish.domain.auth.exception.AuthErrorCode;
+import com.sopt.cherrish.global.response.CommonApiResponse;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void commence(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		AuthenticationException authException
+	) throws IOException {
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+		CommonApiResponse<Void> errorResponse = CommonApiResponse.fail(AuthErrorCode.UNAUTHORIZED);
+		response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+	}
+}

--- a/src/main/java/com/sopt/cherrish/global/security/SecurityErrorResponseWriter.java
+++ b/src/main/java/com/sopt/cherrish/global/security/SecurityErrorResponseWriter.java
@@ -27,19 +27,19 @@ public class SecurityErrorResponseWriter {
 	/**
 	 * 에러 응답을 HTTP Response에 작성합니다.
 	 *
+	 * <p>HTTP 상태 코드는 AuthErrorCode에서 가져옵니다.</p>
+	 *
 	 * @param response HTTP 응답 객체
-	 * @param status HTTP 상태 코드
 	 * @param errorCode 에러 코드
 	 * @throws IOException 응답 작성 중 예외 발생 시
 	 */
 	public void writeErrorResponse(
 		HttpServletResponse response,
-		int status,
 		AuthErrorCode errorCode
 	) throws IOException {
 		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 		response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-		response.setStatus(status);
+		response.setStatus(errorCode.getStatus());
 
 		CommonApiResponse<Void> errorResponse = CommonApiResponse.fail(errorCode);
 		response.getWriter().write(objectMapper.writeValueAsString(errorResponse));

--- a/src/main/java/com/sopt/cherrish/global/security/SecurityErrorResponseWriter.java
+++ b/src/main/java/com/sopt/cherrish/global/security/SecurityErrorResponseWriter.java
@@ -1,0 +1,47 @@
+package com.sopt.cherrish.global.security;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sopt.cherrish.domain.auth.exception.AuthErrorCode;
+import com.sopt.cherrish.global.response.CommonApiResponse;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Security 관련 에러 응답을 작성하는 유틸리티 클래스.
+ *
+ * <p>인증/인가 실패 시 일관된 JSON 응답을 생성합니다.</p>
+ */
+@Component
+@RequiredArgsConstructor
+public class SecurityErrorResponseWriter {
+
+	private final ObjectMapper objectMapper;
+
+	/**
+	 * 에러 응답을 HTTP Response에 작성합니다.
+	 *
+	 * @param response HTTP 응답 객체
+	 * @param status HTTP 상태 코드
+	 * @param errorCode 에러 코드
+	 * @throws IOException 응답 작성 중 예외 발생 시
+	 */
+	public void writeErrorResponse(
+		HttpServletResponse response,
+		int status,
+		AuthErrorCode errorCode
+	) throws IOException {
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+		response.setStatus(status);
+
+		CommonApiResponse<Void> errorResponse = CommonApiResponse.fail(errorCode);
+		response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+	}
+}

--- a/src/main/java/com/sopt/cherrish/global/security/UserPrincipal.java
+++ b/src/main/java/com/sopt/cherrish/global/security/UserPrincipal.java
@@ -12,6 +12,12 @@ import com.sopt.cherrish.domain.user.domain.model.User;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * Spring Security의 UserDetails 구현체.
+ *
+ * <p>JWT 인증 후 SecurityContext에 저장되어 현재 인증된 사용자 정보를 제공합니다.
+ * {@link CurrentUser} 어노테이션을 통해 컨트롤러에서 주입받을 수 있습니다.</p>
+ */
 @Getter
 @RequiredArgsConstructor
 public class UserPrincipal implements UserDetails {
@@ -20,6 +26,12 @@ public class UserPrincipal implements UserDetails {
 	private final String name;
 	private final Collection<? extends GrantedAuthority> authorities;
 
+	/**
+	 * User 엔티티로부터 UserPrincipal을 생성합니다.
+	 *
+	 * @param user 사용자 엔티티
+	 * @return UserPrincipal 인스턴스
+	 */
 	public static UserPrincipal from(User user) {
 		return new UserPrincipal(
 			user.getId(),

--- a/src/main/java/com/sopt/cherrish/global/security/UserPrincipal.java
+++ b/src/main/java/com/sopt/cherrish/global/security/UserPrincipal.java
@@ -1,0 +1,65 @@
+package com.sopt.cherrish.global.security;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.sopt.cherrish.domain.user.domain.model.User;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class UserPrincipal implements UserDetails {
+
+	private final Long userId;
+	private final String name;
+	private final Collection<? extends GrantedAuthority> authorities;
+
+	public static UserPrincipal from(User user) {
+		return new UserPrincipal(
+			user.getId(),
+			user.getName(),
+			Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+		);
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return authorities;
+	}
+
+	@Override
+	public String getPassword() {
+		return null;
+	}
+
+	@Override
+	public String getUsername() {
+		return String.valueOf(userId);
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+}

--- a/src/main/java/com/sopt/cherrish/global/swagger/OpenApiConfigurer.java
+++ b/src/main/java/com/sopt/cherrish/global/swagger/OpenApiConfigurer.java
@@ -2,8 +2,11 @@ package com.sopt.cherrish.global.swagger;
 
 import java.util.List;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 
 public class OpenApiConfigurer {
@@ -11,6 +14,7 @@ public class OpenApiConfigurer {
 	private static final String API_TITLE = "Cherrish API";
 	private static final String API_VERSION = "v1.0.0";
 	private static final String API_DESCRIPTION = "Cherrish API 문서";
+	private static final String SECURITY_SCHEME_NAME = "Bearer Authentication";
 
 	private final String baseUrl;
 
@@ -21,7 +25,27 @@ public class OpenApiConfigurer {
 	public OpenAPI createOpenAPI() {
 		return new OpenAPI()
 			.info(createApiInfo())
-			.servers(createServerList());
+			.servers(createServerList())
+			.components(createComponents())
+			.addSecurityItem(createSecurityRequirement());
+	}
+
+	private Components createComponents() {
+		return new Components()
+			.addSecuritySchemes(SECURITY_SCHEME_NAME, createSecurityScheme());
+	}
+
+	private SecurityScheme createSecurityScheme() {
+		return new SecurityScheme()
+			.name(SECURITY_SCHEME_NAME)
+			.type(SecurityScheme.Type.HTTP)
+			.scheme("bearer")
+			.bearerFormat("JWT")
+			.description("JWT Access Token을 입력하세요. (Bearer 접두사 불필요)");
+	}
+
+	private SecurityRequirement createSecurityRequirement() {
+		return new SecurityRequirement().addList(SECURITY_SCHEME_NAME);
 	}
 
 	private Info createApiInfo() {

--- a/src/main/resources/application-auth.yaml
+++ b/src/main/resources/application-auth.yaml
@@ -1,5 +1,5 @@
 jwt:
-  secret-key: ${JWT_SECRET_KEY:defaultSecretKeyForDevelopmentOnlyPleaseChangeInProduction1234567890}
+  secret-key: ${JWT_SECRET_KEY}
   access-token-expiration: 1800000      # 30분 (밀리초)
   refresh-token-expiration: 1209600000  # 14일 (밀리초)
 

--- a/src/main/resources/application-auth.yaml
+++ b/src/main/resources/application-auth.yaml
@@ -1,0 +1,8 @@
+jwt:
+  secret-key: ${JWT_SECRET_KEY:defaultSecretKeyForDevelopmentOnlyPleaseChangeInProduction1234567890}
+  access-token-expiration: 1800000      # 30분 (밀리초)
+  refresh-token-expiration: 1209600000  # 14일 (밀리초)
+
+social:
+  apple:
+    client-id: ${APPLE_CLIENT_ID:com.sopt.cherrish}  # iOS Bundle ID

--- a/src/main/resources/application-redis.yaml
+++ b/src/main/resources/application-redis.yaml
@@ -4,3 +4,5 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD:}
+      repositories:
+        enabled: false

--- a/src/main/resources/application-redis.yaml
+++ b/src/main/resources/application-redis.yaml
@@ -1,0 +1,6 @@
+spring:
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,6 +7,8 @@ spring:
     include:
       - db
       - openai
+      - auth
+      - redis
 
   config:
     import: optional:file:.env[.properties]

--- a/src/test/java/com/sopt/cherrish/domain/calendar/fixture/CalendarTestFixture.java
+++ b/src/test/java/com/sopt/cherrish/domain/calendar/fixture/CalendarTestFixture.java
@@ -8,6 +8,7 @@ import com.sopt.cherrish.domain.calendar.domain.model.CalendarEventType;
 import com.sopt.cherrish.domain.calendar.presentation.dto.response.CalendarDailyResponseDto;
 import com.sopt.cherrish.domain.calendar.presentation.dto.response.ProcedureEventDowntimeResponseDto;
 import com.sopt.cherrish.domain.calendar.presentation.dto.response.ProcedureEventResponseDto;
+import com.sopt.cherrish.domain.auth.domain.model.SocialProvider;
 import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
 import com.sopt.cherrish.domain.user.domain.model.User;
 import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
@@ -21,6 +22,8 @@ public class CalendarTestFixture {
 		return User.builder()
 			.name(name)
 			.age(age)
+			.socialProvider(SocialProvider.KAKAO)
+			.socialId("test_social_id")
 			.build();
 	}
 

--- a/src/test/java/com/sopt/cherrish/domain/challenge/core/application/facade/ChallengeCreationFacadeIntegrationTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/challenge/core/application/facade/ChallengeCreationFacadeIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,6 +26,7 @@ import com.sopt.cherrish.domain.challenge.core.exception.ChallengeErrorCode;
 import com.sopt.cherrish.domain.challenge.core.exception.ChallengeException;
 import com.sopt.cherrish.domain.challenge.core.presentation.dto.request.ChallengeCreateRequestDto;
 import com.sopt.cherrish.domain.challenge.core.presentation.dto.response.ChallengeCreateResponseDto;
+import com.sopt.cherrish.domain.auth.domain.model.SocialProvider;
 import com.sopt.cherrish.domain.user.domain.model.User;
 import com.sopt.cherrish.domain.user.domain.repository.UserRepository;
 import com.sopt.cherrish.domain.user.exception.UserErrorCode;
@@ -65,6 +67,8 @@ class ChallengeCreationFacadeIntegrationTest {
 		return userRepository.save(User.builder()
 			.name("테스트 유저")
 			.age(25)
+			.socialProvider(SocialProvider.KAKAO)
+			.socialId(UUID.randomUUID().toString())
 			.build());
 	}
 

--- a/src/test/java/com/sopt/cherrish/domain/challenge/core/application/facade/ChallengeCustomRoutineFacadeIntegrationTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/challenge/core/application/facade/ChallengeCustomRoutineFacadeIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ import com.sopt.cherrish.domain.challenge.core.exception.ChallengeErrorCode;
 import com.sopt.cherrish.domain.challenge.core.exception.ChallengeException;
 import com.sopt.cherrish.domain.challenge.core.presentation.dto.request.CustomRoutineAddRequestDto;
 import com.sopt.cherrish.domain.challenge.core.presentation.dto.response.CustomRoutineAddResponseDto;
+import com.sopt.cherrish.domain.auth.domain.model.SocialProvider;
 import com.sopt.cherrish.domain.user.application.service.UserService;
 import com.sopt.cherrish.domain.user.domain.model.User;
 import com.sopt.cherrish.domain.user.domain.repository.UserRepository;
@@ -72,6 +74,8 @@ class ChallengeCustomRoutineFacadeIntegrationTest {
 		return userRepository.save(User.builder()
 			.name("테스트 유저")
 			.age(25)
+			.socialProvider(SocialProvider.KAKAO)
+			.socialId(UUID.randomUUID().toString())
 			.build());
 	}
 
@@ -206,6 +210,8 @@ class ChallengeCustomRoutineFacadeIntegrationTest {
 		User other = userRepository.save(User.builder()
 			.name("다른 유저")
 			.age(30)
+			.socialProvider(SocialProvider.KAKAO)
+			.socialId(UUID.randomUUID().toString())
 			.build());
 
 		createActiveChallengeWithRoutines(owner, 3);

--- a/src/test/java/com/sopt/cherrish/domain/challenge/core/fixture/ChallengeIntegrationTestFixture.java
+++ b/src/test/java/com/sopt/cherrish/domain/challenge/core/fixture/ChallengeIntegrationTestFixture.java
@@ -2,6 +2,7 @@ package com.sopt.cherrish.domain.challenge.core.fixture;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.stereotype.Component;
 
@@ -12,6 +13,7 @@ import com.sopt.cherrish.domain.challenge.core.domain.model.ChallengeStatistics;
 import com.sopt.cherrish.domain.challenge.core.domain.repository.ChallengeRepository;
 import com.sopt.cherrish.domain.challenge.core.domain.repository.ChallengeRoutineRepository;
 import com.sopt.cherrish.domain.challenge.core.domain.repository.ChallengeStatisticsRepository;
+import com.sopt.cherrish.domain.auth.domain.model.SocialProvider;
 import com.sopt.cherrish.domain.user.domain.model.User;
 
 import static com.sopt.cherrish.domain.challenge.core.fixture.ChallengeTestConstants.FIXED_START_DATE;
@@ -73,6 +75,8 @@ public class ChallengeIntegrationTestFixture {
 		return userRepository.save(User.builder()
 			.name(name)
 			.age(age)
+			.socialProvider(SocialProvider.KAKAO)
+			.socialId(UUID.randomUUID().toString())
 			.build());
 	}
 

--- a/src/test/java/com/sopt/cherrish/domain/user/fixture/UserFixture.java
+++ b/src/test/java/com/sopt/cherrish/domain/user/fixture/UserFixture.java
@@ -3,6 +3,7 @@ package com.sopt.cherrish.domain.user.fixture;
 import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 
+import com.sopt.cherrish.domain.auth.domain.model.SocialProvider;
 import com.sopt.cherrish.domain.user.domain.model.User;
 import com.sopt.cherrish.global.entity.BaseTimeEntity;
 
@@ -11,6 +12,8 @@ public class UserFixture {
 	private static final String DEFAULT_NAME = "홍길동";
 	private static final int DEFAULT_AGE = 25;
 	private static final Long DEFAULT_ID = 1L;
+	private static final SocialProvider DEFAULT_SOCIAL_PROVIDER = SocialProvider.KAKAO;
+	private static final String DEFAULT_SOCIAL_ID = "test_social_id_12345";
 
 	private UserFixture() {
 		// Utility class
@@ -24,6 +27,8 @@ public class UserFixture {
 		User user = User.builder()
 			.name(name)
 			.age(age)
+			.socialProvider(DEFAULT_SOCIAL_PROVIDER)
+			.socialId(DEFAULT_SOCIAL_ID)
 			.build();
 		setField(user, User.class, "id", DEFAULT_ID);
 		setField(user, BaseTimeEntity.class, "createdAt", LocalDateTime.now());
@@ -34,6 +39,8 @@ public class UserFixture {
 		User user = User.builder()
 			.name(name)
 			.age(age)
+			.socialProvider(DEFAULT_SOCIAL_PROVIDER)
+			.socialId(DEFAULT_SOCIAL_ID)
 			.build();
 		setField(user, User.class, "id", DEFAULT_ID);
 		setField(user, BaseTimeEntity.class, "createdAt", createdAt);

--- a/src/test/java/com/sopt/cherrish/domain/user/fixture/UserFixture.java
+++ b/src/test/java/com/sopt/cherrish/domain/user/fixture/UserFixture.java
@@ -2,6 +2,7 @@ package com.sopt.cherrish.domain.user.fixture;
 
 import java.lang.reflect.Field;
 import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicLong;
 
 import com.sopt.cherrish.domain.auth.domain.model.SocialProvider;
 import com.sopt.cherrish.domain.user.domain.model.User;
@@ -11,9 +12,10 @@ public class UserFixture {
 
 	private static final String DEFAULT_NAME = "홍길동";
 	private static final int DEFAULT_AGE = 25;
-	private static final Long DEFAULT_ID = 1L;
 	private static final SocialProvider DEFAULT_SOCIAL_PROVIDER = SocialProvider.KAKAO;
-	private static final String DEFAULT_SOCIAL_ID = "test_social_id_12345";
+
+	private static final AtomicLong ID_COUNTER = new AtomicLong(1);
+	private static final AtomicLong SOCIAL_ID_COUNTER = new AtomicLong(1);
 
 	private UserFixture() {
 		// Utility class
@@ -28,9 +30,9 @@ public class UserFixture {
 			.name(name)
 			.age(age)
 			.socialProvider(DEFAULT_SOCIAL_PROVIDER)
-			.socialId(DEFAULT_SOCIAL_ID)
+			.socialId(generateSocialId())
 			.build();
-		setField(user, User.class, "id", DEFAULT_ID);
+		setField(user, User.class, "id", ID_COUNTER.getAndIncrement());
 		setField(user, BaseTimeEntity.class, "createdAt", LocalDateTime.now());
 		return user;
 	}
@@ -40,11 +42,15 @@ public class UserFixture {
 			.name(name)
 			.age(age)
 			.socialProvider(DEFAULT_SOCIAL_PROVIDER)
-			.socialId(DEFAULT_SOCIAL_ID)
+			.socialId(generateSocialId())
 			.build();
-		setField(user, User.class, "id", DEFAULT_ID);
+		setField(user, User.class, "id", ID_COUNTER.getAndIncrement());
 		setField(user, BaseTimeEntity.class, "createdAt", createdAt);
 		return user;
+	}
+
+	private static String generateSocialId() {
+		return "test_social_id_" + SOCIAL_ID_COUNTER.getAndIncrement();
 	}
 
 	private static void setField(Object target, Class<?> clazz, String fieldName, Object value) {

--- a/src/test/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryTest.java
+++ b/src/test/java/com/sopt/cherrish/domain/userprocedure/domain/repository/UserProcedureRepositoryTest.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import com.sopt.cherrish.domain.auth.domain.model.SocialProvider;
 import com.sopt.cherrish.domain.procedure.domain.model.Procedure;
 import com.sopt.cherrish.domain.user.domain.model.User;
 import com.sopt.cherrish.domain.userprocedure.domain.model.UserProcedure;
@@ -183,6 +185,8 @@ class UserProcedureRepositoryTest {
 		User user = User.builder()
 			.name(name)
 			.age(age)
+			.socialProvider(SocialProvider.KAKAO)
+			.socialId(UUID.randomUUID().toString())
 			.build();
 		return entityManager.persist(user);
 	}

--- a/src/test/java/com/sopt/cherrish/global/config/TestAuthConfig.java
+++ b/src/test/java/com/sopt/cherrish/global/config/TestAuthConfig.java
@@ -7,7 +7,6 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 
 import com.sopt.cherrish.domain.auth.domain.repository.AccessTokenBlacklistRepository;
-import com.sopt.cherrish.domain.auth.infrastructure.jwt.JwtProperties;
 import com.sopt.cherrish.domain.auth.infrastructure.jwt.JwtTokenProvider;
 
 @Configuration
@@ -16,17 +15,7 @@ public class TestAuthConfig {
 
 	@Bean
 	@Primary
-	public JwtProperties jwtProperties() {
-		JwtProperties properties = new JwtProperties();
-		properties.setSecretKey("dGVzdC1zZWNyZXQta2V5LWZvci11bml0LXRlc3RzLW11c3QtYmUtYXQtbGVhc3QtMjU2LWJpdHMtbG9uZw==");
-		properties.setAccessTokenExpiration(1800000L);
-		properties.setRefreshTokenExpiration(1209600000L);
-		return properties;
-	}
-
-	@Bean
-	@Primary
-	public JwtTokenProvider jwtTokenProvider(JwtProperties jwtProperties) {
+	public JwtTokenProvider jwtTokenProvider() {
 		return Mockito.mock(JwtTokenProvider.class);
 	}
 

--- a/src/test/java/com/sopt/cherrish/global/config/TestAuthConfig.java
+++ b/src/test/java/com/sopt/cherrish/global/config/TestAuthConfig.java
@@ -1,0 +1,38 @@
+package com.sopt.cherrish.global.config;
+
+import org.mockito.Mockito;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+
+import com.sopt.cherrish.domain.auth.domain.repository.AccessTokenBlacklistRepository;
+import com.sopt.cherrish.domain.auth.infrastructure.jwt.JwtProperties;
+import com.sopt.cherrish.domain.auth.infrastructure.jwt.JwtTokenProvider;
+
+@Configuration
+@Profile("test")
+public class TestAuthConfig {
+
+	@Bean
+	@Primary
+	public JwtProperties jwtProperties() {
+		JwtProperties properties = new JwtProperties();
+		properties.setSecretKey("dGVzdC1zZWNyZXQta2V5LWZvci11bml0LXRlc3RzLW11c3QtYmUtYXQtbGVhc3QtMjU2LWJpdHMtbG9uZw==");
+		properties.setAccessTokenExpiration(1800000L);
+		properties.setRefreshTokenExpiration(1209600000L);
+		return properties;
+	}
+
+	@Bean
+	@Primary
+	public JwtTokenProvider jwtTokenProvider(JwtProperties jwtProperties) {
+		return Mockito.mock(JwtTokenProvider.class);
+	}
+
+	@Bean
+	@Primary
+	public AccessTokenBlacklistRepository accessTokenBlacklistRepository() {
+		return Mockito.mock(AccessTokenBlacklistRepository.class);
+	}
+}

--- a/src/test/java/com/sopt/cherrish/global/config/TestRedisConfig.java
+++ b/src/test/java/com/sopt/cherrish/global/config/TestRedisConfig.java
@@ -1,0 +1,36 @@
+package com.sopt.cherrish.global.config;
+
+import org.mockito.Mockito;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+@Configuration
+@Profile("test")
+public class TestRedisConfig {
+
+	@Bean
+	@Primary
+	@SuppressWarnings("unchecked")
+	public RedisTemplate<String, String> redisTemplate() {
+		RedisTemplate<String, String> mockTemplate = Mockito.mock(RedisTemplate.class);
+		ValueOperations<String, String> mockValueOps = Mockito.mock(ValueOperations.class);
+
+		when(mockTemplate.opsForValue()).thenReturn(mockValueOps);
+		when(mockTemplate.hasKey(anyString())).thenReturn(false);
+		when(mockTemplate.delete(anyString())).thenReturn(true);
+		doNothing().when(mockValueOps).set(anyString(), anyString(), anyLong(), any());
+		when(mockValueOps.get(anyString())).thenReturn(null);
+
+		return mockTemplate;
+	}
+}

--- a/src/test/java/com/sopt/cherrish/global/config/TestSecurityConfig.java
+++ b/src/test/java/com/sopt/cherrish/global/config/TestSecurityConfig.java
@@ -1,0 +1,21 @@
+package com.sopt.cherrish.global.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+public class TestSecurityConfig {
+
+	@Bean
+	@Primary
+	public SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+		return http
+			.csrf(AbstractHttpConfigurer::disable)
+			.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+			.build();
+	}
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -37,11 +37,6 @@ spring:
     openai:
       api-key: test-dummy-api-key-for-unit-tests
 
-  data:
-    redis:
-      host: localhost
-      port: 6379
-
 jwt:
   secret-key: dGVzdC1zZWNyZXQta2V5LWZvci11bml0LXRlc3RzLW11c3QtYmUtYXQtbGVhc3QtMjU2LWJpdHMtbG9uZw==
   access-token-expiration: 1800000

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -7,6 +7,8 @@ spring:
     exclude:
       - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
       - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
+      - org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+      - org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration
 
   datasource:
     url: jdbc:h2:mem:testdb

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -3,10 +3,11 @@ spring:
   profiles:
     active: test
 
+  main:
+    allow-bean-definition-overriding: true
+
   autoconfigure:
     exclude:
-      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
-      - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
       - org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
       - org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration
 

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,5 +1,13 @@
 spring:
 
+  profiles:
+    active: test
+
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
+
   datasource:
     url: jdbc:h2:mem:testdb
     driver-class-name: org.h2.Driver
@@ -25,3 +33,17 @@ spring:
   ai:
     openai:
       api-key: test-dummy-api-key-for-unit-tests
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+jwt:
+  secret-key: dGVzdC1zZWNyZXQta2V5LWZvci11bml0LXRlc3RzLW11c3QtYmUtYXQtbGVhc3QtMjU2LWJpdHMtbG9uZw==
+  access-token-expiration: 1800000
+  refresh-token-expiration: 1209600000
+
+social:
+  apple:
+    client-id: com.test.app


### PR DESCRIPTION
# 🛠 Related issue 🛠

- closed #145

# ✏️ Work Description ✏️

- Spring Security + JWT 인증 시스템 구현
    - Stateless JWT 기반 인증 구성
    - Access Token (30분) / Refresh Token (14일) 발급
    - RTR (Refresh Token Rotation) 적용
- 소셜 로그인 구현 (카카오, 애플)
    - 카카오: Access Token으로 `/v2/user/me` API 호출하여 사용자 정보 조회
    - 애플: Identity Token을 Apple 공개키로 RSA 검증
    - Apple 공개키 24시간 캐싱으로 성능 최적화
- Redis 기반 토큰 관리
    - Refresh Token 저장 (`refresh_token:{userId}`)
    - Access Token 블랙리스트 (`blacklist:{token}`)
    - TTL 기반 자동 만료
- Auth API 엔드포인트
    - `POST /api/auth/login` - 소셜 로그인
    - `POST /api/auth/refresh` - 토큰 재발급
    - `POST /api/auth/logout` - 로그아웃 (RT 삭제 + AT 블랙리스트)
- User 엔티티 확장
    - `socialProvider` (KAKAO, APPLE)
    - `socialId` (소셜 플랫폼 고유 ID)
    - `email`
- 인증 관련 글로벌 설정
    - `SecurityConfig` - Spring Security 필터 체인
    - `JwtAuthenticationFilter` - JWT 검증 필터
    - `JwtAuthenticationEntryPoint` - 401 처리
    - `JwtAccessDeniedHandler` - 403 처리
    - `@CurrentUser` - 현재 사용자 주입 어노테이션

# 📸 Screenshot 📸

| 설명 | 사진 |
| --- | --- |
| 소셜 로그인 API | <img width="1890" height="981" alt="image" src="https://github.com/user-attachments/assets/fa7aff57-c914-4858-8418-93cb4f0bb380" /> |
| 토큰 재발급 API | <img width="1892" height="931" alt="image" src="https://github.com/user-attachments/assets/9dd49d06-8908-47a2-8d33-7e540bbc43e3" /> |
| 로그아웃 API |<img width="1892" height="831" alt="image" src="https://github.com/user-attachments/assets/7286d9a7-91c7-465f-9a34-a5c4fa44fdb6" /> |

# 😅 Uncompleted Tasks 😅

- 기존 컨트롤러 `@RequestHeader("X-User-Id")` → `@CurrentUser UserPrincipal` 변경 (별도 PR 예정)

# 📢 To Reviewers 📢

- `application-auth.yaml`에 `JWT_SECRET_KEY`, `APPLE_CLIENT_ID` 환경변수 설정 필요
- `application-redis.yaml`에 `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD` 환경변수 설정 필요
- Apple 공개키 캐싱 전략: 24시간 캐싱 + kid 불일치 시 강제 갱신 + 네트워크 장애 시 기존 캐시 사용
- Access Token 블랙리스트는 토큰 남은 만료시간만큼 TTL 설정되어 자동 정리됨